### PR TITLE
allow NextRenderersFactory to be extended

### DIFF
--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/NextRenderersFactory.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/NextRenderersFactory.kt
@@ -13,7 +13,7 @@ import androidx.media3.exoplayer.video.VideoRendererEventListener
 
 
 @UnstableApi
-class NextRenderersFactory(context: Context) : DefaultRenderersFactory(context) {
+open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(context) {
 
     override fun buildAudioRenderers(
         context: Context,


### PR DESCRIPTION
IF you need to customize some behaviour of `DefaultRenderersFactory`, now it's not possible when using `NextRenderersFactory` as it's marked as final by default, whereas original `NextRenderersFactory` allows extending.