### PR TITLE
Add runtime decoder switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,16 @@ Create a `DecoderManager` alongside `NextRenderersFactory` when the application 
 video and audio decoders while keeping the same `ExoPlayer` instance:
 
 ```kotlin
-val trackSelector = DefaultTrackSelector(applicationContext)
 val decoderManager = DecoderManager()
 val renderersFactory = NextRenderersFactory(applicationContext)
     .setDecoderManager(decoderManager)
 val player = ExoPlayer.Builder(applicationContext)
     .setRenderersFactory(renderersFactory)
-    .setTrackSelector(trackSelector)
     .build()
 
-decoderManager.attach(player, trackSelector)
+decoderManager.attach(player)
 decoderManager.selectVideoDecoder(DecoderMode.HARDWARE)
-decoderManager.selectAudioDecoder(null)
+decoderManager.selectAudioDecoder(DecoderMode.AUTO)
 
 decoderManager.detach()
 player.release()

--- a/README.md
+++ b/README.md
@@ -27,13 +27,42 @@ dependencies {
 }
 ```
 
-## Usage
+## Basic usage
 
-To use Ffmpeg decoders in your app, Add `NextRenderersFactory` (is one to one compatible with DefaultRenderersFactory) to `ExoPlayer`
+Use `NextRenderersFactory` as a drop-in `DefaultRenderersFactory` replacement to make the bundled
+FFmpeg decoders available to Media3:
+
 ```kotlin
-val renderersFactory = NextRenderersFactory(applicationContext) 
+val renderersFactory = NextRenderersFactory(applicationContext)
 
 ExoPlayer.Builder(applicationContext)
     .setRenderersFactory(renderersFactory)
     .build()
 ```
+
+## Runtime decoder switching
+
+Create a `DecoderManager` alongside `NextRenderersFactory` when the application needs to select
+video and audio decoders while keeping the same `ExoPlayer` instance:
+
+```kotlin
+val trackSelector = DefaultTrackSelector(applicationContext)
+val decoderManager = DecoderManager()
+val renderersFactory = NextRenderersFactory(applicationContext)
+    .setDecoderManager(decoderManager)
+val player = ExoPlayer.Builder(applicationContext)
+    .setRenderersFactory(renderersFactory)
+    .setTrackSelector(trackSelector)
+    .build()
+
+decoderManager.attach(player, trackSelector)
+decoderManager.selectVideoDecoder(DecoderMode.HARDWARE)
+decoderManager.selectAudioDecoder(null)
+
+decoderManager.detach()
+player.release()
+```
+
+Video and audio are selected independently. See
+[`media3ext/DECODER_SWITCHING.md`](media3ext/DECODER_SWITCHING.md) for mode behavior, lifecycle, and
+application-owned error handling.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ subprojects {
             coordinates(
                 groupId = "io.github.anilbeesetti",
                 artifactId = property("POM_ARTIFACT_ID") as String,
-                version = "${libs.versions.androidxMedia3.get()}-0.13.0"
+                version = "${libs.versions.androidxMedia3.get()}-0.14.0"
             )
 
             pom {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,9 @@
 [versions]
 androidCompileSdk = "36"
-agp = "9.2.1"
+agp = "9.3.1"
 kotlin = "2.4.0"
-androidxMedia3 = "1.10.1"
+androidxMedia3 = "1.11.0"
+junit = "4.13.2"
 checkerQual = "3.54.0"
 googleErrorProne = "2.48.0"
 androidxAnnotation = "1.9.1"
@@ -16,6 +17,7 @@ kotlin-annotations-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-annota
 androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "androidxMedia3" }
 checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerQual" }
 google-errorprone-annotations = { group = "com.google.errorprone", name = "error_prone_annotations", version.ref = "googleErrorProne" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }

--- a/media3ext/DECODER_SWITCHING.md
+++ b/media3ext/DECODER_SWITCHING.md
@@ -1,0 +1,98 @@
+# Runtime Decoder Switching
+
+`DecoderManager` lets an application change video and audio decoder categories without replacing
+its `ExoPlayer`. `NextRenderersFactory` creates every required MediaCodec and FFmpeg renderer once,
+and the manager controls the renderer set after the application attaches them.
+
+## Decoder modes
+
+The same `DecoderMode` values are available for video and audio. Each track type is selected
+independently.
+
+| Mode | Behavior |
+| --- | --- |
+| `null` | Automatically prefers hardware MediaCodec, then software MediaCodec, then nextlib FFmpeg |
+| `HARDWARE` | Uses only MediaCodec decoders that Media3 identifies as hardware accelerated |
+| `SOFTWARE` | Uses only MediaCodec decoders that Media3 identifies as software-only |
+| `APP_SOFTWARE` | Uses only the FFmpeg renderer bundled with nextlib |
+
+`SOFTWARE` and `APP_SOFTWARE` are different decoder paths. `SOFTWARE` uses Android's MediaCodec
+software decoders; `APP_SOFTWARE` uses nextlib's FFmpeg implementation.
+
+In automatic mode, the system renderer is evaluated before the FFmpeg renderer. MediaCodec
+candidates are ordered as known hardware, known software-only, then codecs whose acceleration
+category is unknown.
+
+## Setup
+
+Create the manager and pass it to the factory before building the player. Attach the player and
+track selector to the manager before preparing media:
+
+```kotlin
+val trackSelector = DefaultTrackSelector(applicationContext)
+val decoderManager = DecoderManager()
+val renderersFactory = NextRenderersFactory(applicationContext)
+    .setDecoderManager(decoderManager)
+
+val player = ExoPlayer.Builder(applicationContext)
+    .setRenderersFactory(renderersFactory)
+    .setTrackSelector(trackSelector)
+    .build()
+
+decoderManager.attach(player, trackSelector)
+```
+
+A factory instance creates one renderer set and must not be shared by multiple players. Call manager
+methods on the player's application thread. Detach the manager before releasing the player:
+
+```kotlin
+decoderManager.detach()
+player.release()
+```
+
+## Selecting decoders
+
+Video and audio changes do not affect each other:
+
+```kotlin
+decoderManager.selectVideoDecoder(DecoderMode.APP_SOFTWARE)
+decoderManager.selectAudioDecoder(DecoderMode.SOFTWARE)
+```
+
+Applications that want the same category for both tracks should call both methods. Mixed choices do
+not require a special fallback setting; for example, FFmpeg video with automatic audio is:
+
+```kotlin
+decoderManager.selectVideoDecoder(DecoderMode.APP_SOFTWARE)
+decoderManager.selectAudioDecoder(null)
+```
+
+`decoderManager.videoMode` and `decoderManager.audioMode` report the decoder modes currently
+initialized by the player. They are `null` before initialization and while switching. The manager
+updates them from Media3 analytics callbacks, including when automatic selection is enabled.
+Selecting before `attach` fails with a clear lifecycle error.
+
+## Switching mechanics
+
+Mode changes preserve the player instance, playlist, current position, and `playWhenReady` value.
+
+Changing among automatic, `HARDWARE`, and `SOFTWARE` can change which MediaCodec instances are
+eligible. The manager stops and prepares the same player for these transitions so an active codec
+from the previous category is released. Changes between MediaCodec and `APP_SOFTWARE` normally
+remap the affected track to a different renderer without stopping the player.
+
+The selected modes remain active until the application changes them. Nextlib does not reset decoder
+modes when the media item changes.
+
+## Error handling
+
+`DecoderManager` does not listen for decoder errors, inspect unsupported tracks, choose fallback
+modes, or expose recovery state. The application owns those decisions and can call
+`selectVideoDecoder` or `selectAudioDecoder` when it wants to retry another mode.
+
+Automatic mode allows Media3 to select FFmpeg when the MediaCodec renderer does not support a
+format, and MediaCodec can try its eligible decoder candidates. Nextlib does not automatically
+recover from a runtime decoder failure after playback has started.
+
+When retrying after a player error, the application should select the fallback mode and prepare the
+player. It remains responsible for dialogs, retry limits, analytics, and terminal error handling.

--- a/media3ext/DECODER_SWITCHING.md
+++ b/media3ext/DECODER_SWITCHING.md
@@ -1,98 +1,53 @@
-# Runtime Decoder Switching
+# Runtime decoder switching
 
-`DecoderManager` lets an application change video and audio decoder categories without replacing
-its `ExoPlayer`. `NextRenderersFactory` creates every required MediaCodec and FFmpeg renderer once,
-and the manager controls the renderer set after the application attaches them.
-
-## Decoder modes
-
-The same `DecoderMode` values are available for video and audio. Each track type is selected
-independently.
-
-| Mode | Behavior |
-| --- | --- |
-| `null` | Automatically prefers hardware MediaCodec, then software MediaCodec, then nextlib FFmpeg |
-| `HARDWARE` | Uses only MediaCodec decoders that Media3 identifies as hardware accelerated |
-| `SOFTWARE` | Uses only MediaCodec decoders that Media3 identifies as software-only |
-| `APP_SOFTWARE` | Uses only the FFmpeg renderer bundled with nextlib |
-
-`SOFTWARE` and `APP_SOFTWARE` are different decoder paths. `SOFTWARE` uses Android's MediaCodec
-software decoders; `APP_SOFTWARE` uses nextlib's FFmpeg implementation.
-
-In automatic mode, the system renderer is evaluated before the FFmpeg renderer. MediaCodec
-candidates are ordered as known hardware, known software-only, then codecs whose acceleration
-category is unknown.
-
-## Setup
-
-Create the manager and pass it to the factory before building the player. Attach the player and
-track selector to the manager before preparing media:
+`DecoderManager` selects video and audio decoders independently on the same `ExoPlayer`.
 
 ```kotlin
-val trackSelector = DefaultTrackSelector(applicationContext)
 val decoderManager = DecoderManager()
-val renderersFactory = NextRenderersFactory(applicationContext)
-    .setDecoderManager(decoderManager)
+val renderersFactory = NextRenderersFactory(context).setDecoderManager(decoderManager)
+val player = ExoPlayer.Builder(context).setRenderersFactory(renderersFactory).build()
+decoderManager.attach(player) // Before preparing media; requires DefaultTrackSelector.
 
-val player = ExoPlayer.Builder(applicationContext)
-    .setRenderersFactory(renderersFactory)
-    .setTrackSelector(trackSelector)
-    .build()
+decoderManager.selectVideoDecoder(DecoderMode.FFMPEG)
+decoderManager.selectAudioDecoder(DecoderMode.AUTO)
 
-decoderManager.attach(player, trackSelector)
-```
-
-A factory instance creates one renderer set and must not be shared by multiple players. Call manager
-methods on the player's application thread. Detach the manager before releasing the player:
-
-```kotlin
+// Before releasing the player:
 decoderManager.detach()
 player.release()
 ```
 
-## Selecting decoders
+| Mode | Eligible decoders |
+| --- | --- |
+| `AUTO` (default) | Hardware MediaCodec, software MediaCodec, unknown MediaCodec, then bundled FFmpeg |
+| `HARDWARE` | Only MediaCodec decoders identified as hardware accelerated |
+| `SOFTWARE` | Only MediaCodec decoders identified as software-only |
+| `FFMPEG` | Only nextlib's FFmpeg renderer |
 
-Video and audio changes do not affect each other:
+Pass `initialVideoMode` and `initialAudioMode` to the manager to change the initial choices.
+`videoMode` and `audioMode` report requested modes. `activeVideoMode` and `activeAudioMode`
+report initialized decoder categories, or `null` while unknown or disabled. During a switch,
+the previous active category remains until the renderer is disabled or a new decoder initializes.
+Unknown MediaCodec categories remain `null`; automatic selection is reported as the actual
+category once identified. Audio passthrough does not initialize a decoder.
 
-```kotlin
-decoderManager.selectVideoDecoder(DecoderMode.APP_SOFTWARE)
-decoderManager.selectAudioDecoder(DecoderMode.SOFTWARE)
-```
+Use one manager/factory per player and call manager methods on the player's application thread.
+Installing a manager enables extension renderers in normal priority order and MediaCodec
+initialization fallback. Keep extensions enabled; `PREFER` changes automatic renderer priority.
+Custom MediaCodec selectors are retained and their results are filtered by the selected mode.
 
-Applications that want the same category for both tracks should call both methods. Mixed choices do
-not require a special fallback setting; for example, FFmpeg video with automatic audio is:
+Switching retains the player, playlist, position, and `playWhenReady`. Changes among `AUTO`,
+`HARDWARE`, and `SOFTWARE` stop and prepare the player to release existing codecs; a stopped
+or unprepared player stays idle. Switching to/from `FFMPEG` remaps tracks without stopping.
+Choices persist across media items. Renderer capability gating is needed because Media3
+[maps tracks before selecting them](https://github.com/androidx/media/blob/release/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/MappingTrackSelector.java).
 
-```kotlin
-decoderManager.selectVideoDecoder(DecoderMode.APP_SOFTWARE)
-decoderManager.selectAudioDecoder(null)
-```
+Applications own runtime error recovery, retry limits, and UI. `AUTO` permits FFmpeg when
+MediaCodec cannot support a format; it does not recover from runtime decoder failures.
+To retry after an error, select a fallback mode and call `player.prepare()`.
 
-`decoderManager.videoMode` and `decoderManager.audioMode` report the decoder modes currently
-initialized by the player. They are `null` before initialization and while switching. The manager
-updates them from Media3 analytics callbacks, including when automatic selection is enabled.
-Selecting before `attach` fails with a clear lifecycle error.
+## Migration from the initial PR API
 
-## Switching mechanics
-
-Mode changes preserve the player instance, playlist, current position, and `playWhenReady` value.
-
-Changing among automatic, `HARDWARE`, and `SOFTWARE` can change which MediaCodec instances are
-eligible. The manager stops and prepares the same player for these transitions so an active codec
-from the previous category is released. Changes between MediaCodec and `APP_SOFTWARE` normally
-remap the affected track to a different renderer without stopping the player.
-
-The selected modes remain active until the application changes them. Nextlib does not reset decoder
-modes when the media item changes.
-
-## Error handling
-
-`DecoderManager` does not listen for decoder errors, inspect unsupported tracks, choose fallback
-modes, or expose recovery state. The application owns those decisions and can call
-`selectVideoDecoder` or `selectAudioDecoder` when it wants to retry another mode.
-
-Automatic mode allows Media3 to select FFmpeg when the MediaCodec renderer does not support a
-format, and MediaCodec can try its eligible decoder candidates. Nextlib does not automatically
-recover from a runtime decoder failure after playback has started.
-
-When retrying after a player error, the application should select the fallback mode and prepare the
-player. It remains responsible for dialogs, retry limits, analytics, and terminal error handling.
+- Replace `null` selections with `DecoderMode.AUTO` and `APP_SOFTWARE` with `FFMPEG`.
+- Replace `attach(player, trackSelector)` with `attach(player)`.
+- Use `activeVideoMode` / `activeAudioMode` for the former initialized-mode properties;
+  `videoMode` / `audioMode` now consistently report the requested selection.

--- a/media3ext/build.gradle.kts
+++ b/media3ext/build.gradle.kts
@@ -63,4 +63,5 @@ dependencies {
     implementation(libs.androidx.annotation)
     compileOnly(libs.checker.qual)
     compileOnly(libs.kotlin.annotations.jvm)
+    testImplementation(libs.junit)
 }

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManager.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManager.kt
@@ -1,9 +1,10 @@
 package io.github.anilbeesetti.nextlib.media3ext.ffdecoder
 
-import androidx.annotation.OptIn
+import android.os.Looper
 import androidx.media3.common.C
-import androidx.media3.common.Tracks
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DecoderCounters
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
@@ -17,18 +18,24 @@ import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
  */
 @UnstableApi
 class DecoderManager(
-    initialVideoMode: DecoderMode? = null,
-    initialAudioMode: DecoderMode? = null,
+    initialVideoMode: DecoderMode = DecoderMode.AUTO,
+    initialAudioMode: DecoderMode = DecoderMode.AUTO,
 ) {
     /** The video decoder mode currently initialized by the player. */
     @Volatile
-    var videoMode: DecoderMode? = null
+    var activeVideoMode: DecoderMode? = null
         private set
 
     /** The audio decoder mode currently initialized by the player. */
     @Volatile
-    var audioMode: DecoderMode? = null
+    var activeAudioMode: DecoderMode? = null
         private set
+
+    /** The requested video mode, including [DecoderMode.AUTO]. */
+    val videoMode: DecoderMode get() = controller.videoMode
+
+    /** The requested audio mode, including [DecoderMode.AUTO]. */
+    val audioMode: DecoderMode get() = controller.audioMode
 
     internal val controller = DecoderRendererController(initialVideoMode, initialAudioMode)
 
@@ -42,10 +49,9 @@ class DecoderManager(
             initializedTimestampMs: Long,
             initializationDurationMs: Long,
         ) {
-            videoMode = activeDecoderMode(
-                selectedMode = controller.videoMode,
+            activeVideoMode = activeDecoderMode(
                 decoderName = decoderName,
-                mimeType = player?.currentTracks?.selectedMimeType(C.TRACK_TYPE_VIDEO),
+                mimeType = player?.videoFormat?.sampleMimeType,
             )
         }
 
@@ -55,21 +61,34 @@ class DecoderManager(
             initializedTimestampMs: Long,
             initializationDurationMs: Long,
         ) {
-            audioMode = activeDecoderMode(
-                selectedMode = controller.audioMode,
+            activeAudioMode = activeDecoderMode(
                 decoderName = decoderName,
-                mimeType = player?.currentTracks?.selectedMimeType(C.TRACK_TYPE_AUDIO),
+                mimeType = player?.audioFormat?.sampleMimeType,
             )
+        }
+
+        override fun onVideoDisabled(
+            eventTime: AnalyticsListener.EventTime,
+            decoderCounters: DecoderCounters,
+        ) {
+            activeVideoMode = null
+        }
+
+        override fun onAudioDisabled(
+            eventTime: AnalyticsListener.EventTime,
+            decoderCounters: DecoderCounters,
+        ) {
+            activeAudioMode = null
         }
     }
 
     /** Connects this manager to a player and its track selector. */
-    fun attach(
-        player: ExoPlayer,
-        trackSelector: DefaultTrackSelector,
-    ) {
+    fun attach(player: ExoPlayer) {
+        check(Looper.myLooper() == player.applicationLooper) { "Use the player's application thread" }
+        val trackSelector = player.trackSelector as? DefaultTrackSelector
+            ?: error("DecoderManager requires DefaultTrackSelector")
         check(this.player == null) { "DecoderManager is already attached to a player" }
-        check(controller.supportsDecoderSwitching) {
+        check(controller.owns(player)) {
             "Set this DecoderManager on NextRenderersFactory before building the player"
         }
 
@@ -79,76 +98,56 @@ class DecoderManager(
         controller.apply(trackSelector)
     }
 
-    /** Selects [mode] for video without changing audio. `null` enables automatic selection. */
-    fun selectVideoDecoder(mode: DecoderMode?) {
-        select(DecoderTrackType.VIDEO, mode)
+    /** Selects [mode] for video without changing audio. [DecoderMode.AUTO] enables automatic selection. */
+    fun selectVideoDecoder(mode: DecoderMode) {
+        select(C.TRACK_TYPE_VIDEO, mode)
     }
 
-    /** Selects [mode] for audio without changing video. `null` enables automatic selection. */
-    fun selectAudioDecoder(mode: DecoderMode?) {
-        select(DecoderTrackType.AUDIO, mode)
+    /** Selects [mode] for audio without changing video. [DecoderMode.AUTO] enables automatic selection. */
+    fun selectAudioDecoder(mode: DecoderMode) {
+        select(C.TRACK_TYPE_AUDIO, mode)
     }
 
     /** Detaches the player and track selector. Calling this more than once is safe. */
     fun detach() {
         val attachedPlayer = player ?: return
+        check(Looper.myLooper() == attachedPlayer.applicationLooper) { "Use the player's application thread" }
         attachedPlayer.removeAnalyticsListener(analyticsListener)
         player = null
         trackSelector = null
-        videoMode = null
-        audioMode = null
+        activeVideoMode = null
+        activeAudioMode = null
     }
 
-    private fun select(trackType: DecoderTrackType, mode: DecoderMode?) {
+    private fun select(trackType: Int, mode: DecoderMode) {
         val player = checkNotNull(player) { "Attach DecoderManager before selecting a decoder" }
+        check(Looper.myLooper() == player.applicationLooper) { "Use the player's application thread" }
         val trackSelector = checkNotNull(trackSelector)
         val previousMode = controller.mode(trackType)
         if (previousMode == mode) return
 
-        when (trackType) {
-            DecoderTrackType.VIDEO -> videoMode = null
-            DecoderTrackType.AUDIO -> audioMode = null
+        if (trackType == C.TRACK_TYPE_VIDEO) controller.videoMode = mode else controller.audioMode = mode
+        val restart = previousMode.requiresMediaCodecRestart(mode)
+        val shouldPrepare = restart && player.playbackState != Player.STATE_IDLE
+        if (restart) {
+            activeVideoMode = null
+            activeAudioMode = null
+            player.stop()
         }
-        controller.setMode(trackType, mode)
-        if (previousMode.requiresMediaCodecRestart(mode)) {
-            restartPlayer(player, trackSelector, controller)
-        } else {
-            controller.apply(trackSelector)
-        }
-    }
-
-    private fun restartPlayer(
-        player: ExoPlayer,
-        trackSelector: DefaultTrackSelector,
-        controller: DecoderRendererController,
-    ) {
-        val playWhenReady = player.playWhenReady
-        val shouldPrepare = player.mediaItemCount > 0
-        player.stop()
         controller.apply(trackSelector)
-        if (!shouldPrepare) return
-
-        player.prepare()
-        player.playWhenReady = playWhenReady
+        if (shouldPrepare) player.prepare()
     }
-
 }
 
-private val DecoderMode?.usesMediaCodec: Boolean
-    get() = this != DecoderMode.APP_SOFTWARE
-
-private fun DecoderMode?.requiresMediaCodecRestart(other: DecoderMode?): Boolean {
-    return this != other && usesMediaCodec && other.usesMediaCodec
-}
+internal fun DecoderMode.requiresMediaCodecRestart(other: DecoderMode): Boolean =
+    this != other && this != DecoderMode.FFMPEG && other != DecoderMode.FFMPEG
 
 @UnstableApi
 private fun activeDecoderMode(
-    selectedMode: DecoderMode?,
     decoderName: String,
     mimeType: String?,
-): DecoderMode {
-    if (decoderName.contains("ffmpeg", ignoreCase = true)) return DecoderMode.APP_SOFTWARE
-    if (selectedMode != null) return selectedMode
+): DecoderMode? {
+    if (decoderName.contains("ffmpeg", ignoreCase = true)) return DecoderMode.FFMPEG
 
     val codecInfo = mimeType?.let {
         runCatching {
@@ -159,17 +158,9 @@ private fun activeDecoderMode(
             )
         }.getOrNull()?.firstOrNull { info -> info.name == decoderName }
     }
-    return if (codecInfo?.hardwareAccelerated == true) {
-        DecoderMode.HARDWARE
-    } else {
-        DecoderMode.SOFTWARE
+    return when {
+        codecInfo?.hardwareAccelerated == true -> DecoderMode.HARDWARE
+        codecInfo?.softwareOnly == true -> DecoderMode.SOFTWARE
+        else -> null
     }
-}
-
-@OptIn(UnstableApi::class)
-private fun Tracks.selectedMimeType(trackType: Int): String? {
-    return groups.firstOrNull { group -> group.type == trackType && group.isSelected }
-        ?.mediaTrackGroup
-        ?.getFormat(0)
-        ?.sampleMimeType
 }

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManager.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManager.kt
@@ -1,0 +1,175 @@
+package io.github.anilbeesetti.nextlib.media3ext.ffdecoder
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.Tracks
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+
+/**
+ * Changes the video and audio decoders created by [NextRenderersFactory].
+ *
+ * Selection keeps the same player, playlist, position, and `playWhenReady` value. Switching between
+ * MediaCodec categories may stop and prepare that player so an active codec is released.
+ */
+@UnstableApi
+class DecoderManager(
+    initialVideoMode: DecoderMode? = null,
+    initialAudioMode: DecoderMode? = null,
+) {
+    /** The video decoder mode currently initialized by the player. */
+    @Volatile
+    var videoMode: DecoderMode? = null
+        private set
+
+    /** The audio decoder mode currently initialized by the player. */
+    @Volatile
+    var audioMode: DecoderMode? = null
+        private set
+
+    internal val controller = DecoderRendererController(initialVideoMode, initialAudioMode)
+
+    private var player: ExoPlayer? = null
+    private var trackSelector: DefaultTrackSelector? = null
+
+    private val analyticsListener = object : AnalyticsListener {
+        override fun onVideoDecoderInitialized(
+            eventTime: AnalyticsListener.EventTime,
+            decoderName: String,
+            initializedTimestampMs: Long,
+            initializationDurationMs: Long,
+        ) {
+            videoMode = activeDecoderMode(
+                selectedMode = controller.videoMode,
+                decoderName = decoderName,
+                mimeType = player?.currentTracks?.selectedMimeType(C.TRACK_TYPE_VIDEO),
+            )
+        }
+
+        override fun onAudioDecoderInitialized(
+            eventTime: AnalyticsListener.EventTime,
+            decoderName: String,
+            initializedTimestampMs: Long,
+            initializationDurationMs: Long,
+        ) {
+            audioMode = activeDecoderMode(
+                selectedMode = controller.audioMode,
+                decoderName = decoderName,
+                mimeType = player?.currentTracks?.selectedMimeType(C.TRACK_TYPE_AUDIO),
+            )
+        }
+    }
+
+    /** Connects this manager to a player and its track selector. */
+    fun attach(
+        player: ExoPlayer,
+        trackSelector: DefaultTrackSelector,
+    ) {
+        check(this.player == null) { "DecoderManager is already attached to a player" }
+        check(controller.supportsDecoderSwitching) {
+            "Set this DecoderManager on NextRenderersFactory before building the player"
+        }
+
+        this.player = player
+        this.trackSelector = trackSelector
+        player.addAnalyticsListener(analyticsListener)
+        controller.apply(trackSelector)
+    }
+
+    /** Selects [mode] for video without changing audio. `null` enables automatic selection. */
+    fun selectVideoDecoder(mode: DecoderMode?) {
+        select(DecoderTrackType.VIDEO, mode)
+    }
+
+    /** Selects [mode] for audio without changing video. `null` enables automatic selection. */
+    fun selectAudioDecoder(mode: DecoderMode?) {
+        select(DecoderTrackType.AUDIO, mode)
+    }
+
+    /** Detaches the player and track selector. Calling this more than once is safe. */
+    fun detach() {
+        val attachedPlayer = player ?: return
+        attachedPlayer.removeAnalyticsListener(analyticsListener)
+        player = null
+        trackSelector = null
+        videoMode = null
+        audioMode = null
+    }
+
+    private fun select(trackType: DecoderTrackType, mode: DecoderMode?) {
+        val player = checkNotNull(player) { "Attach DecoderManager before selecting a decoder" }
+        val trackSelector = checkNotNull(trackSelector)
+        val previousMode = controller.mode(trackType)
+        if (previousMode == mode) return
+
+        when (trackType) {
+            DecoderTrackType.VIDEO -> videoMode = null
+            DecoderTrackType.AUDIO -> audioMode = null
+        }
+        controller.setMode(trackType, mode)
+        if (previousMode.requiresMediaCodecRestart(mode)) {
+            restartPlayer(player, trackSelector, controller)
+        } else {
+            controller.apply(trackSelector)
+        }
+    }
+
+    private fun restartPlayer(
+        player: ExoPlayer,
+        trackSelector: DefaultTrackSelector,
+        controller: DecoderRendererController,
+    ) {
+        val playWhenReady = player.playWhenReady
+        val shouldPrepare = player.mediaItemCount > 0
+        player.stop()
+        controller.apply(trackSelector)
+        if (!shouldPrepare) return
+
+        player.prepare()
+        player.playWhenReady = playWhenReady
+    }
+
+}
+
+private val DecoderMode?.usesMediaCodec: Boolean
+    get() = this != DecoderMode.APP_SOFTWARE
+
+private fun DecoderMode?.requiresMediaCodecRestart(other: DecoderMode?): Boolean {
+    return this != other && usesMediaCodec && other.usesMediaCodec
+}
+
+@UnstableApi
+private fun activeDecoderMode(
+    selectedMode: DecoderMode?,
+    decoderName: String,
+    mimeType: String?,
+): DecoderMode {
+    if (decoderName.contains("ffmpeg", ignoreCase = true)) return DecoderMode.APP_SOFTWARE
+    if (selectedMode != null) return selectedMode
+
+    val codecInfo = mimeType?.let {
+        runCatching {
+            MediaCodecSelector.DEFAULT.getDecoderInfos(
+                /* mimeType = */ it,
+                /* requiresSecureDecoder = */ decoderName.endsWith(".secure", ignoreCase = true),
+                /* requiresTunnelingDecoder = */ false,
+            )
+        }.getOrNull()?.firstOrNull { info -> info.name == decoderName }
+    }
+    return if (codecInfo?.hardwareAccelerated == true) {
+        DecoderMode.HARDWARE
+    } else {
+        DecoderMode.SOFTWARE
+    }
+}
+
+@OptIn(UnstableApi::class)
+private fun Tracks.selectedMimeType(trackType: Int): String? {
+    return groups.firstOrNull { group -> group.type == trackType && group.isSelected }
+        ?.mediaTrackGroup
+        ?.getFormat(0)
+        ?.sampleMimeType
+}

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManager.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManager.kt
@@ -7,7 +7,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DecoderCounters
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
-import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 
 /**
@@ -49,10 +48,7 @@ class DecoderManager(
             initializedTimestampMs: Long,
             initializationDurationMs: Long,
         ) {
-            activeVideoMode = activeDecoderMode(
-                decoderName = decoderName,
-                mimeType = player?.videoFormat?.sampleMimeType,
-            )
+            activeVideoMode = controller.activeMode(decoderName)
         }
 
         override fun onAudioDecoderInitialized(
@@ -61,10 +57,7 @@ class DecoderManager(
             initializedTimestampMs: Long,
             initializationDurationMs: Long,
         ) {
-            activeAudioMode = activeDecoderMode(
-                decoderName = decoderName,
-                mimeType = player?.audioFormat?.sampleMimeType,
-            )
+            activeAudioMode = controller.activeMode(decoderName)
         }
 
         override fun onVideoDisabled(
@@ -141,26 +134,3 @@ class DecoderManager(
 
 internal fun DecoderMode.requiresMediaCodecRestart(other: DecoderMode): Boolean =
     this != other && this != DecoderMode.FFMPEG && other != DecoderMode.FFMPEG
-
-@UnstableApi
-private fun activeDecoderMode(
-    decoderName: String,
-    mimeType: String?,
-): DecoderMode? {
-    if (decoderName.contains("ffmpeg", ignoreCase = true)) return DecoderMode.FFMPEG
-
-    val codecInfo = mimeType?.let {
-        runCatching {
-            MediaCodecSelector.DEFAULT.getDecoderInfos(
-                /* mimeType = */ it,
-                /* requiresSecureDecoder = */ decoderName.endsWith(".secure", ignoreCase = true),
-                /* requiresTunnelingDecoder = */ false,
-            )
-        }.getOrNull()?.firstOrNull { info -> info.name == decoderName }
-    }
-    return when {
-        codecInfo?.hardwareAccelerated == true -> DecoderMode.HARDWARE
-        codecInfo?.softwareOnly == true -> DecoderMode.SOFTWARE
-        else -> null
-    }
-}

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderMode.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderMode.kt
@@ -2,6 +2,9 @@ package io.github.anilbeesetti.nextlib.media3ext.ffdecoder
 
 /** Selects which decoder category is eligible for a video or audio track. */
 enum class DecoderMode {
+    /** Prefers hardware MediaCodec, then software MediaCodec, then bundled FFmpeg. */
+    AUTO,
+
     /** Uses only MediaCodec decoders that Media3 identifies as hardware accelerated. */
     HARDWARE,
 
@@ -9,5 +12,5 @@ enum class DecoderMode {
     SOFTWARE,
 
     /** Uses only the FFmpeg renderer bundled with nextlib. */
-    APP_SOFTWARE,
+    FFMPEG,
 }

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderMode.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderMode.kt
@@ -1,0 +1,13 @@
+package io.github.anilbeesetti.nextlib.media3ext.ffdecoder
+
+/** Selects which decoder category is eligible for a video or audio track. */
+enum class DecoderMode {
+    /** Uses only MediaCodec decoders that Media3 identifies as hardware accelerated. */
+    HARDWARE,
+
+    /** Uses only MediaCodec decoders that Media3 identifies as software-only. */
+    SOFTWARE,
+
+    /** Uses only the FFmpeg renderer bundled with nextlib. */
+    APP_SOFTWARE,
+}

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererController.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererController.kt
@@ -11,13 +11,26 @@ import androidx.media3.exoplayer.RendererCapabilities
 import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import java.util.concurrent.ConcurrentHashMap
 
 @UnstableApi
 internal class DecoderRendererController(
     @Volatile var videoMode: DecoderMode,
     @Volatile var audioMode: DecoderMode,
 ) {
+    internal val decoderInfos = ConcurrentHashMap<String, MediaCodecInfo>()
+
     private var renderers: Array<Renderer>? = null
+
+    fun activeMode(decoderName: String): DecoderMode? {
+        if (decoderName.startsWith("ffmpeg")) return DecoderMode.FFMPEG
+        val info = decoderInfos[decoderName]
+        return when {
+            info?.hardwareAccelerated == true -> DecoderMode.HARDWARE
+            info?.softwareOnly == true -> DecoderMode.SOFTWARE
+            else -> null
+        }
+    }
 
     fun owns(player: ExoPlayer): Boolean = renderers?.let { renderers ->
         player.rendererCount == renderers.size &&
@@ -71,6 +84,7 @@ internal class DecoderMediaCodecSelector(
             requiresSecureDecoder,
             requiresTunnelingDecoder,
         )
+        decoderInfos.forEach { controller.decoderInfos[it.name] = it }
         val mode = when {
             MimeTypes.isVideo(mimeType) -> controller.videoMode
             MimeTypes.isAudio(mimeType) -> controller.audioMode

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererController.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererController.kt
@@ -1,0 +1,182 @@
+package io.github.anilbeesetti.nextlib.media3ext.ffdecoder
+
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ForwardingRenderer
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.RendererCapabilities
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+
+@UnstableApi
+internal class DecoderRendererController(
+    initialVideoMode: DecoderMode?,
+    initialAudioMode: DecoderMode?,
+) {
+    @Volatile
+    var videoMode: DecoderMode? = initialVideoMode
+        private set
+
+    @Volatile
+    var audioMode: DecoderMode? = initialAudioMode
+        private set
+
+    val supportsDecoderSwitching: Boolean
+        get() = DecoderRendererRole.entries.all { role ->
+            managedRenderers.any { renderer -> renderer.role == role }
+        }
+
+    fun setMode(trackType: DecoderTrackType, mode: DecoderMode?) {
+        when (trackType) {
+            DecoderTrackType.VIDEO -> videoMode = mode
+            DecoderTrackType.AUDIO -> audioMode = mode
+        }
+    }
+
+    fun mode(trackType: DecoderTrackType): DecoderMode? {
+        return when (trackType) {
+            DecoderTrackType.VIDEO -> videoMode
+            DecoderTrackType.AUDIO -> audioMode
+        }
+    }
+
+    fun wrapRenderers(renderers: Array<Renderer>): Array<Renderer> {
+        check(managedRenderers.isEmpty()) { "NextRenderersFactory can only create one renderer set" }
+        return renderers.mapIndexed { index, renderer ->
+            val role = renderer.decoderRole() ?: return@mapIndexed renderer
+            managedRenderers += ManagedRenderer(index, role)
+            ModeAwareRenderer(renderer) { role.isEnabled(videoMode, audioMode) }
+        }.toTypedArray()
+    }
+
+    fun apply(trackSelector: DefaultTrackSelector) {
+        val parameters = trackSelector.buildUponParameters()
+        managedRenderers.forEach { renderer ->
+            parameters.setRendererDisabled(
+                renderer.index,
+                !renderer.role.isEnabled(videoMode, audioMode),
+            )
+        }
+        trackSelector.setParameters(parameters)
+    }
+
+    private val managedRenderers = mutableListOf<ManagedRenderer>()
+}
+
+internal enum class DecoderTrackType {
+    VIDEO,
+    AUDIO,
+}
+
+@UnstableApi
+internal class DecoderMediaCodecSelector(
+    private val controller: DecoderRendererController,
+    private val delegate: MediaCodecSelector = MediaCodecSelector.DEFAULT,
+) : MediaCodecSelector {
+    override fun getDecoderInfos(
+        mimeType: String,
+        requiresSecureDecoder: Boolean,
+        requiresTunnelingDecoder: Boolean,
+    ): List<MediaCodecInfo> {
+        val decoderInfos = delegate.getDecoderInfos(
+            mimeType,
+            requiresSecureDecoder,
+            requiresTunnelingDecoder,
+        )
+        val mode = when {
+            MimeTypes.isVideo(mimeType) -> controller.videoMode
+            MimeTypes.isAudio(mimeType) -> controller.audioMode
+            else -> return decoderInfos
+        }
+        return when (mode) {
+            null -> decoderInfos.sortedBy(MediaCodecInfo::decoderPriority)
+            DecoderMode.HARDWARE -> decoderInfos.filter(MediaCodecInfo::hardwareAccelerated)
+            DecoderMode.SOFTWARE -> decoderInfos.filter(MediaCodecInfo::softwareOnly)
+            DecoderMode.APP_SOFTWARE -> emptyList()
+        }
+    }
+}
+
+internal enum class DecoderRendererRole {
+    SYSTEM_VIDEO,
+    APP_SOFTWARE_VIDEO,
+    SYSTEM_AUDIO,
+    APP_SOFTWARE_AUDIO,
+    ;
+
+    fun isEnabled(videoMode: DecoderMode?, audioMode: DecoderMode?): Boolean {
+        return when (this) {
+            SYSTEM_VIDEO -> videoMode != DecoderMode.APP_SOFTWARE
+            APP_SOFTWARE_VIDEO ->
+                videoMode == null || videoMode == DecoderMode.APP_SOFTWARE
+            SYSTEM_AUDIO -> audioMode != DecoderMode.APP_SOFTWARE
+            APP_SOFTWARE_AUDIO ->
+                audioMode == null || audioMode == DecoderMode.APP_SOFTWARE
+        }
+    }
+}
+
+private data class ManagedRenderer(
+    val index: Int,
+    val role: DecoderRendererRole,
+)
+
+@UnstableApi
+private class ModeAwareRenderer(
+    delegate: Renderer,
+    isEnabled: () -> Boolean,
+) : ForwardingRenderer(delegate) {
+    private val modeAwareCapabilities = ModeAwareCapabilities(delegate.capabilities, isEnabled)
+
+    override fun getCapabilities(): RendererCapabilities = modeAwareCapabilities
+}
+
+@UnstableApi
+private class ModeAwareCapabilities(
+    private val delegate: RendererCapabilities,
+    private val isEnabled: () -> Boolean,
+) : RendererCapabilities {
+    override fun getName(): String = delegate.name
+
+    override fun getTrackType(): Int = delegate.trackType
+
+    override fun supportsFormat(format: Format): Int {
+        if (!isEnabled()) return RendererCapabilities.create(C.FORMAT_UNSUPPORTED_TYPE)
+        return delegate.supportsFormat(format)
+    }
+
+    override fun supportsMixedMimeTypeAdaptation(): Int = delegate.supportsMixedMimeTypeAdaptation()
+
+    override fun setListener(listener: RendererCapabilities.Listener) {
+        delegate.setListener(listener)
+    }
+
+    override fun clearListener() {
+        delegate.clearListener()
+    }
+}
+
+@UnstableApi
+private fun Renderer.decoderRole(): DecoderRendererRole? {
+    return when (this) {
+        is FfmpegVideoRenderer -> DecoderRendererRole.APP_SOFTWARE_VIDEO
+        is FfmpegAudioRenderer -> DecoderRendererRole.APP_SOFTWARE_AUDIO
+        else -> when (capabilities.trackType) {
+            C.TRACK_TYPE_VIDEO -> DecoderRendererRole.SYSTEM_VIDEO
+            C.TRACK_TYPE_AUDIO -> DecoderRendererRole.SYSTEM_AUDIO
+            else -> null
+        }
+    }
+}
+
+@UnstableApi
+private fun MediaCodecInfo.decoderPriority(): Int {
+    return when {
+        hardwareAccelerated -> 0
+        softwareOnly -> 1
+        else -> 2
+    }
+}

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererController.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererController.kt
@@ -4,6 +4,7 @@ import androidx.media3.common.C
 import androidx.media3.common.Format
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.ForwardingRenderer
 import androidx.media3.exoplayer.Renderer
 import androidx.media3.exoplayer.RendererCapabilities
@@ -13,63 +14,47 @@ import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 
 @UnstableApi
 internal class DecoderRendererController(
-    initialVideoMode: DecoderMode?,
-    initialAudioMode: DecoderMode?,
+    @Volatile var videoMode: DecoderMode,
+    @Volatile var audioMode: DecoderMode,
 ) {
-    @Volatile
-    var videoMode: DecoderMode? = initialVideoMode
-        private set
+    private var renderers: Array<Renderer>? = null
 
-    @Volatile
-    var audioMode: DecoderMode? = initialAudioMode
-        private set
+    fun owns(player: ExoPlayer): Boolean = renderers?.let { renderers ->
+        player.rendererCount == renderers.size &&
+            renderers.indices.all { player.getRenderer(it) === renderers[it] }
+    } ?: false
 
-    val supportsDecoderSwitching: Boolean
-        get() = DecoderRendererRole.entries.all { role ->
-            managedRenderers.any { renderer -> renderer.role == role }
-        }
-
-    fun setMode(trackType: DecoderTrackType, mode: DecoderMode?) {
-        when (trackType) {
-            DecoderTrackType.VIDEO -> videoMode = mode
-            DecoderTrackType.AUDIO -> audioMode = mode
-        }
-    }
-
-    fun mode(trackType: DecoderTrackType): DecoderMode? {
-        return when (trackType) {
-            DecoderTrackType.VIDEO -> videoMode
-            DecoderTrackType.AUDIO -> audioMode
-        }
-    }
+    fun mode(trackType: Int): DecoderMode =
+        if (trackType == C.TRACK_TYPE_VIDEO) videoMode else audioMode
 
     fun wrapRenderers(renderers: Array<Renderer>): Array<Renderer> {
-        check(managedRenderers.isEmpty()) { "NextRenderersFactory can only create one renderer set" }
-        return renderers.mapIndexed { index, renderer ->
-            val role = renderer.decoderRole() ?: return@mapIndexed renderer
-            managedRenderers += ManagedRenderer(index, role)
-            ModeAwareRenderer(renderer) { role.isEnabled(videoMode, audioMode) }
-        }.toTypedArray()
+        check(this.renderers == null) { "NextRenderersFactory can only create one renderer set" }
+        check(renderers.any { it is FfmpegVideoRenderer } && renderers.any { it is FfmpegAudioRenderer }) {
+            "Runtime decoder switching requires FFmpeg audio and video renderers"
+        }
+        return renderers.map { renderer ->
+            when (renderer.trackType) {
+                C.TRACK_TYPE_VIDEO, C.TRACK_TYPE_AUDIO -> ModeAwareRenderer(renderer) {
+                    mode(renderer.trackType).enables(renderer is FfmpegVideoRenderer || renderer is FfmpegAudioRenderer)
+                }
+                else -> renderer
+            }
+        }.toTypedArray().also { this.renderers = it }
     }
 
     fun apply(trackSelector: DefaultTrackSelector) {
         val parameters = trackSelector.buildUponParameters()
-        managedRenderers.forEach { renderer ->
-            parameters.setRendererDisabled(
-                renderer.index,
-                !renderer.role.isEnabled(videoMode, audioMode),
-            )
+        renderers?.forEachIndexed { index, renderer ->
+            if (renderer is ModeAwareRenderer) {
+                parameters.setRendererDisabled(index, !renderer.isEnabled())
+            }
         }
         trackSelector.setParameters(parameters)
     }
-
-    private val managedRenderers = mutableListOf<ManagedRenderer>()
 }
 
-internal enum class DecoderTrackType {
-    VIDEO,
-    AUDIO,
-}
+internal fun DecoderMode.enables(ffmpeg: Boolean): Boolean =
+    this == DecoderMode.AUTO || (this == DecoderMode.FFMPEG) == ffmpeg
 
 @UnstableApi
 internal class DecoderMediaCodecSelector(
@@ -92,84 +77,27 @@ internal class DecoderMediaCodecSelector(
             else -> return decoderInfos
         }
         return when (mode) {
-            null -> decoderInfos.sortedBy(MediaCodecInfo::decoderPriority)
+            DecoderMode.AUTO -> decoderInfos.sortedBy(MediaCodecInfo::decoderPriority)
             DecoderMode.HARDWARE -> decoderInfos.filter(MediaCodecInfo::hardwareAccelerated)
             DecoderMode.SOFTWARE -> decoderInfos.filter(MediaCodecInfo::softwareOnly)
-            DecoderMode.APP_SOFTWARE -> emptyList()
+            DecoderMode.FFMPEG -> emptyList()
         }
     }
 }
-
-internal enum class DecoderRendererRole {
-    SYSTEM_VIDEO,
-    APP_SOFTWARE_VIDEO,
-    SYSTEM_AUDIO,
-    APP_SOFTWARE_AUDIO,
-    ;
-
-    fun isEnabled(videoMode: DecoderMode?, audioMode: DecoderMode?): Boolean {
-        return when (this) {
-            SYSTEM_VIDEO -> videoMode != DecoderMode.APP_SOFTWARE
-            APP_SOFTWARE_VIDEO ->
-                videoMode == null || videoMode == DecoderMode.APP_SOFTWARE
-            SYSTEM_AUDIO -> audioMode != DecoderMode.APP_SOFTWARE
-            APP_SOFTWARE_AUDIO ->
-                audioMode == null || audioMode == DecoderMode.APP_SOFTWARE
-        }
-    }
-}
-
-private data class ManagedRenderer(
-    val index: Int,
-    val role: DecoderRendererRole,
-)
 
 @UnstableApi
-private class ModeAwareRenderer(
+internal class ModeAwareRenderer(
     delegate: Renderer,
-    isEnabled: () -> Boolean,
+    val isEnabled: () -> Boolean,
 ) : ForwardingRenderer(delegate) {
-    private val modeAwareCapabilities = ModeAwareCapabilities(delegate.capabilities, isEnabled)
+    // MappingTrackSelector maps tracks before considering disabled renderer flags.
+    private val modeAwareCapabilities = object : RendererCapabilities by delegate.capabilities {
+        override fun supportsFormat(format: Format): Int =
+            if (isEnabled()) delegate.capabilities.supportsFormat(format)
+            else RendererCapabilities.create(C.FORMAT_UNSUPPORTED_TYPE)
+    }
 
     override fun getCapabilities(): RendererCapabilities = modeAwareCapabilities
-}
-
-@UnstableApi
-private class ModeAwareCapabilities(
-    private val delegate: RendererCapabilities,
-    private val isEnabled: () -> Boolean,
-) : RendererCapabilities {
-    override fun getName(): String = delegate.name
-
-    override fun getTrackType(): Int = delegate.trackType
-
-    override fun supportsFormat(format: Format): Int {
-        if (!isEnabled()) return RendererCapabilities.create(C.FORMAT_UNSUPPORTED_TYPE)
-        return delegate.supportsFormat(format)
-    }
-
-    override fun supportsMixedMimeTypeAdaptation(): Int = delegate.supportsMixedMimeTypeAdaptation()
-
-    override fun setListener(listener: RendererCapabilities.Listener) {
-        delegate.setListener(listener)
-    }
-
-    override fun clearListener() {
-        delegate.clearListener()
-    }
-}
-
-@UnstableApi
-private fun Renderer.decoderRole(): DecoderRendererRole? {
-    return when (this) {
-        is FfmpegVideoRenderer -> DecoderRendererRole.APP_SOFTWARE_VIDEO
-        is FfmpegAudioRenderer -> DecoderRendererRole.APP_SOFTWARE_AUDIO
-        else -> when (capabilities.trackType) {
-            C.TRACK_TYPE_VIDEO -> DecoderRendererRole.SYSTEM_VIDEO
-            C.TRACK_TYPE_AUDIO -> DecoderRendererRole.SYSTEM_AUDIO
-            else -> null
-        }
-    }
 }
 
 @UnstableApi

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/NextRenderersFactory.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/NextRenderersFactory.kt
@@ -18,17 +18,17 @@ import io.github.anilbeesetti.nextlib.media3ext.renderer.NextTextRenderer
 /**
  * A [DefaultRenderersFactory] with nextlib's FFmpeg renderers and runtime decoder switching support.
  *
- * The renderer set starts in [DecoderMode]. Create a [DecoderManager] separately and attach it
+ * Create a [DecoderManager] separately and attach it
  * after building the player to change video or audio modes.
  */
 @UnstableApi
 open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(context) {
     private var decoderManager: DecoderManager? = null
 
-    fun setDecoderManager(decoderManager: DecoderManager): DefaultRenderersFactory = this.apply {
+    fun setDecoderManager(decoderManager: DecoderManager): NextRenderersFactory = this.apply {
         this.decoderManager = decoderManager
         this.setEnableDecoderFallback(true)
-        this.setMediaCodecSelector(DecoderMediaCodecSelector(decoderManager.controller))
+        this.setExtensionRendererMode(EXTENSION_RENDERER_MODE_ON)
     }
 
     override fun createRenderers(
@@ -61,7 +61,8 @@ open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(cont
         super.buildAudioRenderers(
             context,
             extensionRendererMode,
-            mediaCodecSelector,
+            decoderManager?.let { DecoderMediaCodecSelector(it.controller, mediaCodecSelector) }
+                ?: mediaCodecSelector,
             enableDecoderFallback,
             audioSink,
             eventHandler,
@@ -99,7 +100,8 @@ open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(cont
         super.buildVideoRenderers(
             context,
             extensionRendererMode,
-            mediaCodecSelector,
+            decoderManager?.let { DecoderMediaCodecSelector(it.controller, mediaCodecSelector) }
+                ?: mediaCodecSelector,
             enableDecoderFallback,
             eventHandler,
             eventListener,

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/NextRenderersFactory.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/NextRenderersFactory.kt
@@ -10,13 +10,43 @@ import androidx.media3.exoplayer.Renderer
 import androidx.media3.exoplayer.audio.AudioRendererEventListener
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.metadata.MetadataOutput
 import androidx.media3.exoplayer.text.TextOutput
 import androidx.media3.exoplayer.video.VideoRendererEventListener
 import io.github.anilbeesetti.nextlib.media3ext.renderer.NextTextRenderer
 
-
+/**
+ * A [DefaultRenderersFactory] with nextlib's FFmpeg renderers and runtime decoder switching support.
+ *
+ * The renderer set starts in [DecoderMode]. Create a [DecoderManager] separately and attach it
+ * after building the player to change video or audio modes.
+ */
 @UnstableApi
 open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(context) {
+    private var decoderManager: DecoderManager? = null
+
+    fun setDecoderManager(decoderManager: DecoderManager): DefaultRenderersFactory = this.apply {
+        this.decoderManager = decoderManager
+        this.setEnableDecoderFallback(true)
+        this.setMediaCodecSelector(DecoderMediaCodecSelector(decoderManager.controller))
+    }
+
+    override fun createRenderers(
+        eventHandler: Handler,
+        videoRendererEventListener: VideoRendererEventListener,
+        audioRendererEventListener: AudioRendererEventListener,
+        textRendererOutput: TextOutput,
+        metadataRendererOutput: MetadataOutput,
+    ): Array<Renderer> {
+        val renderers = super.createRenderers(
+            eventHandler,
+            videoRendererEventListener,
+            audioRendererEventListener,
+            textRendererOutput,
+            metadataRendererOutput,
+        )
+        return decoderManager?.controller?.wrapRenderers(renderers) ?: renderers
+    }
 
     override fun buildAudioRenderers(
         context: Context,
@@ -26,7 +56,7 @@ open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(cont
         audioSink: AudioSink,
         eventHandler: Handler,
         eventListener: AudioRendererEventListener,
-        out: ArrayList<Renderer>
+        out: ArrayList<Renderer>,
     ) {
         super.buildAudioRenderers(
             context,
@@ -36,7 +66,7 @@ open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(cont
             audioSink,
             eventHandler,
             eventListener,
-            out
+            out,
         )
 
         if (extensionRendererMode == EXTENSION_RENDERER_MODE_OFF) return
@@ -64,7 +94,7 @@ open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(cont
         eventHandler: Handler,
         eventListener: VideoRendererEventListener,
         allowedVideoJoiningTimeMs: Long,
-        out: ArrayList<Renderer>
+        out: ArrayList<Renderer>,
     ) {
         super.buildVideoRenderers(
             context,
@@ -74,7 +104,7 @@ open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(cont
             eventHandler,
             eventListener,
             allowedVideoJoiningTimeMs,
-            out
+            out,
         )
 
         if (extensionRendererMode == EXTENSION_RENDERER_MODE_OFF) return
@@ -85,12 +115,17 @@ open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(cont
         }
 
         try {
-            val renderer = FfmpegVideoRenderer(allowedVideoJoiningTimeMs, eventHandler, eventListener, MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY)
+            val renderer = FfmpegVideoRenderer(
+                /* allowedJoiningTimeMs = */ allowedVideoJoiningTimeMs,
+                /* eventHandler = */ eventHandler,
+                /* eventListener = */ eventListener,
+                /* maxDroppedFramesToNotify = */ MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY,
+            )
             out.add(extensionRendererIndex++, renderer)
             Log.i(TAG, "Loaded FfmpegVideoRenderer.")
-        } catch (e: java.lang.Exception) {
+        } catch (e: Exception) {
             // The extension is present, but instantiation failed.
-            throw java.lang.RuntimeException("Error instantiating Ffmpeg extension", e)
+            throw RuntimeException("Error instantiating Ffmpeg extension", e)
         }
     }
 
@@ -99,7 +134,7 @@ open class NextRenderersFactory(context: Context) : DefaultRenderersFactory(cont
         output: TextOutput,
         outputLooper: Looper,
         extensionRendererMode: Int,
-        out: java.util.ArrayList<Renderer>
+        out: ArrayList<Renderer>,
     ) {
         out.add(NextTextRenderer(output, outputLooper))
     }

--- a/media3ext/src/test/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManagerTest.kt
+++ b/media3ext/src/test/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManagerTest.kt
@@ -15,8 +15,20 @@ class DecoderManagerTest {
             initialAudioMode = DecoderMode.SOFTWARE,
         )
 
-        assertNull(manager.videoMode)
-        assertNull(manager.audioMode)
+        assertEquals(DecoderMode.HARDWARE, manager.videoMode)
+        assertEquals(DecoderMode.SOFTWARE, manager.audioMode)
+        assertNull(manager.activeVideoMode)
+        assertNull(manager.activeAudioMode)
+    }
+
+    @Test
+    fun onlyChangesBetweenMediaCodecModesRequireRestart() {
+        assertEquals(true, DecoderMode.AUTO.requiresMediaCodecRestart(DecoderMode.HARDWARE))
+        assertEquals(true, DecoderMode.HARDWARE.requiresMediaCodecRestart(DecoderMode.SOFTWARE))
+        assertEquals(true, DecoderMode.SOFTWARE.requiresMediaCodecRestart(DecoderMode.AUTO))
+        assertEquals(false, DecoderMode.HARDWARE.requiresMediaCodecRestart(DecoderMode.HARDWARE))
+        assertEquals(false, DecoderMode.AUTO.requiresMediaCodecRestart(DecoderMode.FFMPEG))
+        assertEquals(false, DecoderMode.FFMPEG.requiresMediaCodecRestart(DecoderMode.HARDWARE))
     }
 
     @Test
@@ -24,7 +36,7 @@ class DecoderManagerTest {
         val manager = DecoderManager()
 
         val error = assertThrows(IllegalStateException::class.java) {
-            manager.selectVideoDecoder(DecoderMode.APP_SOFTWARE)
+            manager.selectVideoDecoder(DecoderMode.FFMPEG)
         }
 
         assertEquals("Attach DecoderManager before selecting a decoder", error.message)

--- a/media3ext/src/test/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManagerTest.kt
+++ b/media3ext/src/test/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManagerTest.kt
@@ -1,0 +1,32 @@
+package io.github.anilbeesetti.nextlib.media3ext.ffdecoder
+
+import androidx.media3.common.util.UnstableApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+@UnstableApi
+class DecoderManagerTest {
+    @Test
+    fun activeModesAreUnknownBeforeDecoderInitialization() {
+        val manager = DecoderManager(
+            initialVideoMode = DecoderMode.HARDWARE,
+            initialAudioMode = DecoderMode.SOFTWARE,
+        )
+
+        assertNull(manager.videoMode)
+        assertNull(manager.audioMode)
+    }
+
+    @Test
+    fun selectingBeforeAttachFailsClearly() {
+        val manager = DecoderManager()
+
+        val error = assertThrows(IllegalStateException::class.java) {
+            manager.selectVideoDecoder(DecoderMode.APP_SOFTWARE)
+        }
+
+        assertEquals("Attach DecoderManager before selecting a decoder", error.message)
+    }
+}

--- a/media3ext/src/test/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererControllerTest.kt
+++ b/media3ext/src/test/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererControllerTest.kt
@@ -1,0 +1,125 @@
+package io.github.anilbeesetti.nextlib.media3ext.ffdecoder
+
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@UnstableApi
+class DecoderRendererControllerTest {
+    @Test
+    fun rendererRolesFollowVideoAndAudioModesIndependently() {
+        assertTrue(
+            DecoderRendererRole.SYSTEM_VIDEO.isEnabled(
+                videoMode = DecoderMode.HARDWARE,
+                audioMode = DecoderMode.APP_SOFTWARE,
+            ),
+        )
+        assertFalse(
+            DecoderRendererRole.APP_SOFTWARE_VIDEO.isEnabled(
+                videoMode = DecoderMode.HARDWARE,
+                audioMode = DecoderMode.APP_SOFTWARE,
+            ),
+        )
+        assertFalse(
+            DecoderRendererRole.SYSTEM_AUDIO.isEnabled(
+                videoMode = DecoderMode.HARDWARE,
+                audioMode = DecoderMode.APP_SOFTWARE,
+            ),
+        )
+        assertTrue(
+            DecoderRendererRole.APP_SOFTWARE_AUDIO.isEnabled(
+                videoMode = DecoderMode.HARDWARE,
+                audioMode = DecoderMode.APP_SOFTWARE,
+            ),
+        )
+    }
+
+    @Test
+    fun nullModeEnablesSystemAndAppSoftwareRenderers() {
+        DecoderRendererRole.entries.forEach { role ->
+            assertTrue(role.isEnabled(null, null))
+        }
+    }
+
+    @Test
+    fun videoAndAudioModesChangeIndependently() {
+        val controller = DecoderRendererController(null, null)
+
+        controller.setMode(DecoderTrackType.VIDEO, DecoderMode.APP_SOFTWARE)
+
+        assertEquals(DecoderMode.APP_SOFTWARE, controller.videoMode)
+        assertNull(controller.audioMode)
+
+        controller.setMode(DecoderTrackType.AUDIO, DecoderMode.SOFTWARE)
+
+        assertEquals(DecoderMode.APP_SOFTWARE, controller.videoMode)
+        assertEquals(DecoderMode.SOFTWARE, controller.audioMode)
+    }
+
+    @Test
+    fun autoOrdersHardwareThenSoftwareThenUnknownCodecs() {
+        val controller = DecoderRendererController(null, null)
+        val selector = DecoderMediaCodecSelector(controller, codecSelector)
+
+        val result = selector.getDecoderInfos(MimeTypes.VIDEO_H264, false, false)
+
+        assertEquals(listOf("hardware", "software", "unknown"), result.map(MediaCodecInfo::name))
+    }
+
+    @Test
+    fun hardwareAndSoftwareFilterTheirMediaCodecCategories() {
+        val controller = DecoderRendererController(DecoderMode.HARDWARE, DecoderMode.SOFTWARE)
+        val selector = DecoderMediaCodecSelector(controller, codecSelector)
+
+        val video = selector.getDecoderInfos(MimeTypes.VIDEO_H264, false, false)
+        val audio = selector.getDecoderInfos(MimeTypes.AUDIO_AAC, false, false)
+
+        assertEquals(listOf("hardware"), video.map(MediaCodecInfo::name))
+        assertEquals(listOf("software"), audio.map(MediaCodecInfo::name))
+    }
+
+    @Test
+    fun appSoftwareDisablesMediaCodecForOnlyTheSelectedTrackType() {
+        val controller = DecoderRendererController(DecoderMode.APP_SOFTWARE, DecoderMode.HARDWARE)
+        val selector = DecoderMediaCodecSelector(controller, codecSelector)
+
+        val video = selector.getDecoderInfos(MimeTypes.VIDEO_H264, false, false)
+        val audio = selector.getDecoderInfos(MimeTypes.AUDIO_AAC, false, false)
+
+        assertTrue(video.isEmpty())
+        assertEquals(listOf("hardware"), audio.map(MediaCodecInfo::name))
+    }
+
+    private val codecSelector = MediaCodecSelector { mimeType, _, _ ->
+        listOf(
+            codecInfo("unknown", mimeType),
+            codecInfo("software", mimeType, softwareOnly = true),
+            codecInfo("hardware", mimeType, hardwareAccelerated = true),
+        )
+    }
+
+    private fun codecInfo(
+        name: String,
+        mimeType: String,
+        hardwareAccelerated: Boolean = false,
+        softwareOnly: Boolean = false,
+    ): MediaCodecInfo {
+        return MediaCodecInfo.newInstance(
+            name,
+            mimeType,
+            mimeType,
+            null,
+            hardwareAccelerated,
+            softwareOnly,
+            false,
+            false,
+            false,
+        )
+    }
+}

--- a/media3ext/src/test/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererControllerTest.kt
+++ b/media3ext/src/test/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererControllerTest.kt
@@ -1,70 +1,36 @@
 package io.github.anilbeesetti.nextlib.media3ext.ffdecoder
 
+import androidx.media3.common.C
+import androidx.media3.common.Format
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.RendererCapabilities
 import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.lang.reflect.Proxy
 
 @UnstableApi
 class DecoderRendererControllerTest {
     @Test
-    fun rendererRolesFollowVideoAndAudioModesIndependently() {
-        assertTrue(
-            DecoderRendererRole.SYSTEM_VIDEO.isEnabled(
-                videoMode = DecoderMode.HARDWARE,
-                audioMode = DecoderMode.APP_SOFTWARE,
-            ),
-        )
-        assertFalse(
-            DecoderRendererRole.APP_SOFTWARE_VIDEO.isEnabled(
-                videoMode = DecoderMode.HARDWARE,
-                audioMode = DecoderMode.APP_SOFTWARE,
-            ),
-        )
-        assertFalse(
-            DecoderRendererRole.SYSTEM_AUDIO.isEnabled(
-                videoMode = DecoderMode.HARDWARE,
-                audioMode = DecoderMode.APP_SOFTWARE,
-            ),
-        )
-        assertTrue(
-            DecoderRendererRole.APP_SOFTWARE_AUDIO.isEnabled(
-                videoMode = DecoderMode.HARDWARE,
-                audioMode = DecoderMode.APP_SOFTWARE,
-            ),
-        )
-    }
-
-    @Test
-    fun nullModeEnablesSystemAndAppSoftwareRenderers() {
-        DecoderRendererRole.entries.forEach { role ->
-            assertTrue(role.isEnabled(null, null))
+    fun modesEnableOnlyTheirRendererCategory() {
+        assertTrue(DecoderMode.AUTO.enables(ffmpeg = false))
+        assertTrue(DecoderMode.AUTO.enables(ffmpeg = true))
+        for (mode in listOf(DecoderMode.HARDWARE, DecoderMode.SOFTWARE)) {
+            assertTrue(mode.enables(ffmpeg = false))
+            assertFalse(mode.enables(ffmpeg = true))
         }
-    }
-
-    @Test
-    fun videoAndAudioModesChangeIndependently() {
-        val controller = DecoderRendererController(null, null)
-
-        controller.setMode(DecoderTrackType.VIDEO, DecoderMode.APP_SOFTWARE)
-
-        assertEquals(DecoderMode.APP_SOFTWARE, controller.videoMode)
-        assertNull(controller.audioMode)
-
-        controller.setMode(DecoderTrackType.AUDIO, DecoderMode.SOFTWARE)
-
-        assertEquals(DecoderMode.APP_SOFTWARE, controller.videoMode)
-        assertEquals(DecoderMode.SOFTWARE, controller.audioMode)
+        assertFalse(DecoderMode.FFMPEG.enables(ffmpeg = false))
+        assertTrue(DecoderMode.FFMPEG.enables(ffmpeg = true))
     }
 
     @Test
     fun autoOrdersHardwareThenSoftwareThenUnknownCodecs() {
-        val controller = DecoderRendererController(null, null)
+        val controller = DecoderRendererController(DecoderMode.AUTO, DecoderMode.AUTO)
         val selector = DecoderMediaCodecSelector(controller, codecSelector)
 
         val result = selector.getDecoderInfos(MimeTypes.VIDEO_H264, false, false)
@@ -85,8 +51,8 @@ class DecoderRendererControllerTest {
     }
 
     @Test
-    fun appSoftwareDisablesMediaCodecForOnlyTheSelectedTrackType() {
-        val controller = DecoderRendererController(DecoderMode.APP_SOFTWARE, DecoderMode.HARDWARE)
+    fun ffmpegDisablesMediaCodecForOnlyTheSelectedTrackType() {
+        val controller = DecoderRendererController(DecoderMode.FFMPEG, DecoderMode.HARDWARE)
         val selector = DecoderMediaCodecSelector(controller, codecSelector)
 
         val video = selector.getDecoderInfos(MimeTypes.VIDEO_H264, false, false)
@@ -94,6 +60,59 @@ class DecoderRendererControllerTest {
 
         assertTrue(video.isEmpty())
         assertEquals(listOf("hardware"), audio.map(MediaCodecInfo::name))
+    }
+
+    @Test
+    fun existingSelectorReadsChangedModesAndPreservesQueryFlags() {
+        val controller = DecoderRendererController(DecoderMode.AUTO, DecoderMode.HARDWARE)
+        val selector = DecoderMediaCodecSelector(controller) { mimeType, secure, tunneling ->
+            assertEquals(MimeTypes.VIDEO_H264, mimeType)
+            assertTrue(secure)
+            assertTrue(tunneling)
+            codecSelector.getDecoderInfos(mimeType, secure, tunneling)
+        }
+        controller.videoMode = DecoderMode.SOFTWARE
+        assertEquals(
+            listOf("software"),
+            selector.getDecoderInfos(MimeTypes.VIDEO_H264, true, true).map { it.name },
+        )
+        assertEquals(DecoderMode.HARDWARE, controller.audioMode)
+    }
+
+    @Test
+    fun capabilityGateHidesDisabledRendererAndRestoresDelegateSupport() {
+        val supported = RendererCapabilities.create(C.FORMAT_HANDLED)
+        val capabilities = Proxy.newProxyInstance(
+            RendererCapabilities::class.java.classLoader,
+            arrayOf(RendererCapabilities::class.java),
+        ) { _, method, _ ->
+            when (method.name) {
+                "supportsFormat" -> supported
+                "getTrackType" -> C.TRACK_TYPE_VIDEO
+                "getName" -> "test"
+                else -> error("Unexpected capability call: ${method.name}")
+            }
+        } as RendererCapabilities
+        val renderer = Proxy.newProxyInstance(
+            Renderer::class.java.classLoader,
+            arrayOf(Renderer::class.java),
+        ) { _, method, _ ->
+            when (method.name) {
+                "getCapabilities" -> capabilities
+                else -> error("Unexpected renderer call: ${method.name}")
+            }
+        } as Renderer
+        var enabled = true
+        val gated = ModeAwareRenderer(renderer) { enabled }.capabilities
+        val format = Format.Builder().setSampleMimeType(MimeTypes.VIDEO_H264).build()
+
+        assertEquals(supported, gated.supportsFormat(format))
+        enabled = false
+        assertEquals(C.FORMAT_UNSUPPORTED_TYPE, RendererCapabilities.getFormatSupport(gated.supportsFormat(format)))
+        enabled = true
+        assertEquals(supported, gated.supportsFormat(format))
+        assertEquals(C.TRACK_TYPE_VIDEO, gated.trackType)
+        assertEquals("test", gated.name)
     }
 
     private val codecSelector = MediaCodecSelector { mimeType, _, _ ->

--- a/media3ext/src/test/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererControllerTest.kt
+++ b/media3ext/src/test/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderRendererControllerTest.kt
@@ -11,11 +11,23 @@ import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNull
 import org.junit.Test
 import java.lang.reflect.Proxy
 
 @UnstableApi
 class DecoderRendererControllerTest {
+    @Test
+    fun initializedDecoderUsesQueriedCodecInfoWithoutPlayerFormat() {
+        val controller = DecoderRendererController(DecoderMode.AUTO, DecoderMode.AUTO)
+        DecoderMediaCodecSelector(controller, codecSelector).getDecoderInfos(MimeTypes.VIDEO_H264, false, false)
+        assertEquals(DecoderMode.HARDWARE, controller.activeMode("hardware"))
+        assertEquals(DecoderMode.SOFTWARE, controller.activeMode("software"))
+        assertEquals(DecoderMode.FFMPEG, controller.activeMode("ffmpeg6.0-h264"))
+        assertNull(controller.activeMode("unknown"))
+        assertNull(controller.activeMode("not-queried"))
+    }
+
     @Test
     fun modesEnableOnlyTheirRendererCategory() {
         assertTrue(DecoderMode.AUTO.enables(ffmpeg = false))


### PR DESCRIPTION
## Summary
- add `DecoderManager` for independent runtime video and audio decoder selection
- support hardware MediaCodec, system software MediaCodec, bundled FFmpeg, and nullable automatic selection without recreating `ExoPlayer`
- integrate the manager with `NextRenderersFactory` and expose the active decoder modes from analytics callbacks
- document the API and add focused manager/renderer-controller tests
- align the library with Media3 1.11.0 and release version 0.14.0

## Testing
- `./gradlew :media3ext:testDebugUnitTest :media3ext:assembleRelease`
- `git diff --check`