### PR TITLE
Modernize FFmpeg setup with Android CLI and shared Gradle task

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,5 +43,8 @@ jobs:
 
       - uses: actions/upload-artifact@v6.0.0
         with:
-          name: nextlib-release.aar
-          path: ./ffcodecs/build/outputs/aar/ffcodecs-release.aar
+          name: nextlib-release
+          if-no-files-found: error
+          path: |
+            media3ext/build/outputs/aar/media3ext-release.aar
+            mediainfo/build/outputs/aar/mediainfo-release.aar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,11 +22,21 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      - name: Install Android CLI
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL --retry 3 https://dl.google.com/android/cli/latest/linux_x86_64/android -o "$HOME/.local/bin/android"
+          chmod +x "$HOME/.local/bin/android"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
           validate-wrappers: true
           gradle-home-cache-cleanup: true
+
+      - name: Check FFmpeg setup
+        run: python3 ffmpeg/test_setup.py
 
       - name: Build Project with gradle
         run: ./gradlew assembleRelease

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,13 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      - name: Install Android CLI
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL --retry 3 https://dl.google.com/android/cli/latest/linux_x86_64/android -o "$HOME/.local/bin/android"
+          chmod +x "$HOME/.local/bin/android"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:

--- a/README.md
+++ b/README.md
@@ -37,3 +37,32 @@ ExoPlayer.Builder(applicationContext)
     .setRenderersFactory(renderersFactory)
     .build()
 ```
+
+## Building from source
+
+Use macOS or Linux (WSL on Windows), JDK 17+, `make`, `curl`, `tar`, and
+`pkg-config`. On Apple Silicon, also install native `yasm` (`brew install yasm`)
+for the x86 ABIs; the pinned NDK bundles an Intel-only assembler. Install [Android CLI](https://developer.android.com/tools/agents/android-cli/download)
+and put `android` on PATH, or set `ANDROID_CLI` to its executable path.
+Set `sdk.dir` in `local.properties` or export `ANDROID_HOME` to your Android SDK.
+
+```sh
+./gradlew assembleRelease
+```
+
+Both modules depend on one `:ffmpegSetup` task, which installs missing NDK/CMake
+packages with Android CLI and builds the four supported ABIs before CMake runs.
+NDK and CMake versions come from `gradle/libs.versions.toml`. Existing SDK tools
+are reused; Android CLI is only needed when a package is missing. Complete any
+SDK license prompts during initial installation before running a headless build.
+
+Gradle tracks the setup script, tool versions, and generated output so unchanged
+builds skip FFmpeg. To force rebuilding it:
+
+```sh
+./gradlew :ffmpegSetup --rerun-tasks
+```
+
+For standalone use, export `ANDROID_HOME` and run `bash ffmpeg/setup.sh` (always
+rebuilds). Run `python3 ffmpeg/test_setup.py` for setup regression checks without
+SDK downloads or native compilation.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,28 @@ plugins {
     alias(libs.plugins.mavenPublish) apply false
 }
 
+// One shared producer for both modules, including parallel Gradle builds.
+val ffmpegSetup = tasks.register<Exec>("ffmpegSetup") {
+    group = "build"
+    description = "Build FFmpeg and its dependencies for all Android ABIs"
+    workingDir = file("ffmpeg")
+    val sdkDirectory = providers.fileContents(layout.projectDirectory.file("local.properties"))
+        .asText.orElse("").map { contents ->
+            java.util.Properties().apply { load(contents.reader()) }.getProperty("sdk.dir", "")
+        }.get().ifBlank {
+            providers.environmentVariable("ANDROID_HOME")
+                .orElse(providers.environmentVariable("ANDROID_SDK_ROOT")).getOrElse("")
+        }
+    environment("ANDROID_HOME", sdkDirectory)
+    environment("ANDROID_NDK_VERSION", libs.versions.ndk.get())
+    environment("ANDROID_CMAKE_VERSION", libs.versions.cmake.get())
+    inputs.file(file("ffmpeg/setup.sh"))
+    inputs.property("ndkVersion", libs.versions.ndk.get())
+    inputs.property("cmakeVersion", libs.versions.cmake.get())
+    outputs.dir(file("ffmpeg/output"))
+    commandLine("bash", "setup.sh")
+}
+
 subprojects {
     plugins.withId(rootProject.libs.plugins.mavenPublish.get().pluginId) {
         configure<com.vanniktech.maven.publish.MavenPublishBaseExtension> {

--- a/ffmpeg/setup.sh
+++ b/ffmpeg/setup.sh
@@ -58,6 +58,8 @@ for tool in curl tar make pkg-config; do
   command -v "$tool" >/dev/null || { echo "Missing build tool: $tool" >&2; exit 1; }
 done
 
+X86_AS=$(command -v yasm || printf '%s\n' "${TOOLCHAIN_PREFIX}/bin/yasm")
+
 mkdir -p "$SOURCES_DIR"
 
 # Publish a source directory only after a complete download and extraction.
@@ -87,12 +89,12 @@ function buildLibVpx() {
       ;;
     x86)
       EXTRA_BUILD_FLAGS="--force-target=x86-android-gcc --disable-sse2 --disable-sse3 --disable-ssse3 --disable-sse4_1 --disable-avx --disable-avx2 --enable-pic"
-      VPX_AS=$(command -v yasm || printf '%s\n' "${TOOLCHAIN_PREFIX}/bin/yasm")
+      VPX_AS=$X86_AS
       TOOLCHAIN=i686-linux-android21-
       ;;
     x86_64)
       EXTRA_BUILD_FLAGS="--force-target=x86_64-android-gcc --disable-sse2 --disable-sse3 --disable-ssse3 --disable-sse4_1 --disable-avx --disable-avx2 --enable-pic --disable-neon --disable-neon-asm"
-      VPX_AS=$(command -v yasm || printf '%s\n' "${TOOLCHAIN_PREFIX}/bin/yasm")
+      VPX_AS=$X86_AS
       TOOLCHAIN=x86_64-linux-android21-
       ;;
     *)
@@ -211,6 +213,7 @@ function buildFfmpeg() {
     ./configure \
       --prefix="$BUILD_DIR/$ABI" \
       --enable-cross-compile \
+      --x86asmexe="$X86_AS" \
       --arch=$ARCH \
       --cpu=$CPU \
       --cross-prefix="${TOOLCHAIN_PREFIX}/bin/$TOOLCHAIN" \

--- a/ffmpeg/setup.sh
+++ b/ffmpeg/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Versions
 VPX_VERSION=1.13.0
@@ -18,82 +19,62 @@ MBEDTLS_DIR=$SOURCES_DIR/mbedtls-$MBEDTLS_VERSION
 ANDROID_ABIS="x86 x86_64 armeabi-v7a arm64-v8a"
 ANDROID_PLATFORM=21
 ENABLED_DECODERS="vorbis opus flac alac pcm_mulaw pcm_alaw mp3 amrnb amrwb aac ac3 eac3 dca mlp truehd h264 hevc mpeg2video mpegvideo libvpx_vp8 libvpx_vp9"
-JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || sysctl -n hw.pysicalcpu || echo 4)
+JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || sysctl -n hw.physicalcpu 2>/dev/null || echo 4)
 
-# Set up host platform variables
-HOST_PLATFORM="linux-x86_64"
-case "$OSTYPE" in
-darwin*) HOST_PLATFORM="darwin-x86_64" ;;
-linux*) HOST_PLATFORM="linux-x86_64" ;;
-msys)
-  case "$(uname -m)" in
-  x86_64) HOST_PLATFORM="windows-x86_64" ;;
-  i686) HOST_PLATFORM="windows" ;;
-  esac
-  ;;
+# Gradle supplies these; standalone callers use the same pinned versions.
+CATALOG="$BASE_DIR/../gradle/libs.versions.toml"
+ANDROID_HOME=${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}
+: "${ANDROID_HOME:?Set ANDROID_HOME to your Android SDK directory}"
+ANDROID_NDK_VERSION=${ANDROID_NDK_VERSION:-$(sed -n 's/^ndk = "\(.*\)"/\1/p' "$CATALOG")}
+ANDROID_CMAKE_VERSION=${ANDROID_CMAKE_VERSION:-$(sed -n 's/^cmake = "\(.*\)"/\1/p' "$CATALOG")}
+: "${ANDROID_NDK_VERSION:?Missing NDK version}"
+: "${ANDROID_CMAKE_VERSION:?Missing CMake version}"
+ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION"
+CMAKE_EXECUTABLE="$ANDROID_HOME/cmake/$ANDROID_CMAKE_VERSION/bin/cmake"
+
+case "$(uname -s)" in
+  Darwin) HOST_PLATFORM=darwin-x86_64 ;;
+  Linux) HOST_PLATFORM=linux-x86_64 ;;
+  *) echo "Build FFmpeg on macOS or Linux (WSL on Windows)." >&2; exit 1 ;;
 esac
+TOOLCHAIN_PREFIX="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$HOST_PLATFORM"
 
-# Build tools
-TOOLCHAIN_PREFIX="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${HOST_PLATFORM}"
-CMAKE_EXECUTABLE="${ANDROID_SDK_HOME}/cmake/${ANDROID_CMAKE_VERSION}/bin/cmake"
-
-# Check if sdkmanager is in PATH
-if command -v sdkmanager &> /dev/null; then
-  # Use sdkmanager from PATH
-  echo "Using sdkmanager from PATH"
-  echo y | sdkmanager --sdk_root="${ANDROID_SDK_HOME}" "cmake;${ANDROID_CMAKE_VERSION}"
-else
-  # Use sdkmanager from Android SDK
-  SDKMANAGER_EXECUTABLE="${ANDROID_SDK_HOME}/cmdline-tools/latest/bin/sdkmanager"
-  if [[ -x "$SDKMANAGER_EXECUTABLE" ]]; then
-    echo "Using sdkmanager from Android SDK"
-    echo y | "$SDKMANAGER_EXECUTABLE" --sdk_root="${ANDROID_SDK_HOME}" "cmake;${ANDROID_CMAKE_VERSION}"
-  else
-    echo "Error: sdkmanager not found in PATH or Android SDK"
+PACKAGES=()
+[[ -x "$TOOLCHAIN_PREFIX/bin/clang" ]] || PACKAGES+=("ndk/$ANDROID_NDK_VERSION")
+[[ -x "$CMAKE_EXECUTABLE" ]] || PACKAGES+=("cmake/$ANDROID_CMAKE_VERSION")
+if (( ${#PACKAGES[@]} )); then
+  ANDROID_CLI=${ANDROID_CLI:-android}
+  command -v "$ANDROID_CLI" >/dev/null || {
+    echo "Install Android CLI from https://developer.android.com/tools/agents and add android to PATH (or set ANDROID_CLI)." >&2
     exit 1
-  fi
+  }
+  "$ANDROID_CLI" --sdk="$ANDROID_HOME" sdk install "${PACKAGES[@]}"
 fi
-
-mkdir -p $SOURCES_DIR
-
-function downloadLibVpx() {
-  pushd $SOURCES_DIR
-  echo "Downloading Vpx source code of version $VPX_VERSION..."
-  VPX_FILE=libvpx-$VPX_VERSION.tar.gz
-  curl -L "https://github.com/webmproject/libvpx/archive/refs/tags/v${VPX_VERSION}.tar.gz" -o $VPX_FILE
-  [ -e $VPX_FILE ] || { echo "$VPX_FILE does not exist. Exiting..."; exit 1; }
-  tar -zxf $VPX_FILE
-  rm $VPX_FILE
-  popd
+[[ -x "$TOOLCHAIN_PREFIX/bin/clang" && -x "$CMAKE_EXECUTABLE" ]] || {
+  echo "Android NDK or CMake installation is incomplete." >&2
+  exit 1
 }
+for tool in curl tar make pkg-config; do
+  command -v "$tool" >/dev/null || { echo "Missing build tool: $tool" >&2; exit 1; }
+done
 
-function downloadMbedTLS() {
-  pushd $SOURCES_DIR
-  echo "Downloading mbedtls source code of version $MBEDTLS_VERSION..."
-  MBEDTLS_FILE=mbedtls-$MBEDTLS_VERSION.tar.gz
-  curl -L "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v${MBEDTLS_VERSION}.tar.gz" -o $MBEDTLS_FILE
-  [ -e $MBEDTLS_FILE ] || { echo "$MBEDTLS_FILE does not exist. Exiting..."; exit 1; }
-  tar -zxf $MBEDTLS_FILE
-  rm $MBEDTLS_FILE
-  popd
-}
+mkdir -p "$SOURCES_DIR"
 
-function downloadFfmpeg() {
-  pushd $SOURCES_DIR
-  echo "Downloading FFmpeg source code of version $FFMPEG_VERSION..."
-  FFMPEG_FILE=ffmpeg-$FFMPEG_VERSION.tar.gz
-  curl -L "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz" -o $FFMPEG_FILE
-  [ -e $FFMPEG_FILE ] || { echo "$FFMPEG_FILE does not exist. Exiting..."; exit 1; }
-  tar -zxf $FFMPEG_FILE
-  rm $FFMPEG_FILE
-  popd
-}
+# Publish a source directory only after a complete download and extraction.
+downloadSource() (
+  destination=$2
+  staging=$(mktemp -d "$SOURCES_DIR/.download.XXXXXX")
+  trap 'rm -rf "$staging"' EXIT
+  curl --fail --location --retry 3 "$1" -o "$staging/source.tar.gz"
+  tar -zxf "$staging/source.tar.gz" -C "$staging"
+  mv "$staging/$(basename "$destination")" "$destination"
+)
 
 function buildLibVpx() {
-  pushd $VPX_DIR
+  pushd "$VPX_DIR"
 
-  VPX_AS=${TOOLCHAIN_PREFIX}/bin/llvm-as
   for ABI in $ANDROID_ABIS; do
+    VPX_AS=${TOOLCHAIN_PREFIX}/bin/llvm-as
     # Set up environment variables
     case $ABI in
     armeabi-v7a)
@@ -106,12 +87,12 @@ function buildLibVpx() {
       ;;
     x86)
       EXTRA_BUILD_FLAGS="--force-target=x86-android-gcc --disable-sse2 --disable-sse3 --disable-ssse3 --disable-sse4_1 --disable-avx --disable-avx2 --enable-pic"
-      VPX_AS=${TOOLCHAIN_PREFIX}/bin/yasm
+      VPX_AS=$(command -v yasm || printf '%s\n' "${TOOLCHAIN_PREFIX}/bin/yasm")
       TOOLCHAIN=i686-linux-android21-
       ;;
     x86_64)
       EXTRA_BUILD_FLAGS="--force-target=x86_64-android-gcc --disable-sse2 --disable-sse3 --disable-ssse3 --disable-sse4_1 --disable-avx --disable-avx2 --enable-pic --disable-neon --disable-neon-asm"
-      VPX_AS=${TOOLCHAIN_PREFIX}/bin/yasm
+      VPX_AS=$(command -v yasm || printf '%s\n' "${TOOLCHAIN_PREFIX}/bin/yasm")
       TOOLCHAIN=x86_64-linux-android21-
       ;;
     *)
@@ -120,16 +101,17 @@ function buildLibVpx() {
       ;;
     esac
 
-    CC=${TOOLCHAIN_PREFIX}/bin/${TOOLCHAIN}clang \
-      CXX=${CC}++ \
-      LD=${CC} \
+    CC="${TOOLCHAIN_PREFIX}/bin/${TOOLCHAIN}clang"
+    CC="$CC" \
+      CXX="${CC}++" \
+      LD="$CC" \
       AR=${TOOLCHAIN_PREFIX}/bin/llvm-ar \
       AS=${VPX_AS} \
       STRIP=${TOOLCHAIN_PREFIX}/bin/llvm-strip \
       NM=${TOOLCHAIN_PREFIX}/bin/llvm-nm \
       LDFLAGS="-Wl,-z,max-page-size=16384" \
       ./configure \
-      --prefix=$BUILD_DIR/external/$ABI \
+      --prefix="$BUILD_DIR/external/$ABI" \
       --libc="${TOOLCHAIN_PREFIX}/sysroot" \
       --enable-vp8 \
       --enable-vp9 \
@@ -154,20 +136,20 @@ function buildLibVpx() {
 }
 
 function buildMbedTLS() {
-    pushd $MBEDTLS_DIR
+    pushd "$MBEDTLS_DIR"
 
     for ABI in $ANDROID_ABIS; do
 
       CMAKE_BUILD_DIR=$MBEDTLS_DIR/mbedtls_build_${ABI}
-      rm -rf ${CMAKE_BUILD_DIR}
-      mkdir -p ${CMAKE_BUILD_DIR}
-      cd ${CMAKE_BUILD_DIR}
+      rm -rf "${CMAKE_BUILD_DIR}"
+      mkdir -p "${CMAKE_BUILD_DIR}"
+      cd "${CMAKE_BUILD_DIR}"
 
-      ${CMAKE_EXECUTABLE} .. \
+      "${CMAKE_EXECUTABLE}" .. \
        -DANDROID_PLATFORM=${ANDROID_PLATFORM} \
        -DANDROID_ABI=$ABI \
-       -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake \
-       -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/external/$ABI \
+       -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" \
+       -DCMAKE_INSTALL_PREFIX="$BUILD_DIR/external/$ABI" \
        -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384" \
        -DENABLE_TESTING=0
 
@@ -179,7 +161,7 @@ function buildMbedTLS() {
 }
 
 function buildFfmpeg() {
-  pushd $FFMPEG_DIR
+  pushd "$FFMPEG_DIR"
   EXTRA_BUILD_CONFIGURATION_FLAGS=""
   COMMON_OPTIONS=""
 
@@ -190,6 +172,7 @@ function buildFfmpeg() {
 
   # Build FFmpeg for each architecture and platform
   for ABI in $ANDROID_ABIS; do
+    EXTRA_BUILD_CONFIGURATION_FLAGS=""
 
     # Set up environment variables
     case $ABI in
@@ -226,7 +209,7 @@ function buildFfmpeg() {
 
     # Configure FFmpeg build
     ./configure \
-      --prefix=$BUILD_DIR/$ABI \
+      --prefix="$BUILD_DIR/$ABI" \
       --enable-cross-compile \
       --arch=$ARCH \
       --cpu=$CPU \
@@ -237,7 +220,7 @@ function buildFfmpeg() {
       --strip="${TOOLCHAIN_PREFIX}/bin/llvm-strip" \
       --extra-cflags="-O3 -fPIC $DEP_CFLAGS" \
       --extra-ldflags="$DEP_LD_FLAGS -Wl,-z,max-page-size=16384" \
-      --pkg-config="$(which pkg-config)" \
+      --pkg-config="$(command -v pkg-config)" \
       --target-os=android \
       --enable-shared \
       --disable-static \
@@ -281,24 +264,16 @@ function buildFfmpeg() {
   popd
 }
 
-if [[ ! -d "$OUTPUT_DIR" && ! -d "$BUILD_DIR" ]]; then
-  # Download MbedTLS source code if it doesn't exist
-  if [[ ! -d "$MBEDTLS_DIR" ]]; then
-    downloadMbedTLS
-  fi
-
-  # Download Vpx source code if it doesn't exist
-  if [[ ! -d "$VPX_DIR" ]]; then
-    downloadLibVpx
-  fi
-
-  # Download Ffmpeg source code if it doesn't exist
-  if [[ ! -d "$FFMPEG_DIR" ]]; then
-    downloadFfmpeg
-  fi
-
-  # Building library
-  buildMbedTLS
-  buildLibVpx
-  buildFfmpeg
+# Gradle owns up-to-date checks. Existing directories can be left by failed builds.
+if [[ ! -d "$MBEDTLS_DIR" ]]; then
+  downloadSource "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v${MBEDTLS_VERSION}.tar.gz" "$MBEDTLS_DIR"
 fi
+if [[ ! -d "$VPX_DIR" ]]; then
+  downloadSource "https://github.com/webmproject/libvpx/archive/refs/tags/v${VPX_VERSION}.tar.gz" "$VPX_DIR"
+fi
+if [[ ! -d "$FFMPEG_DIR" ]]; then
+  downloadSource "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz" "$FFMPEG_DIR"
+fi
+buildMbedTLS
+buildLibVpx
+buildFfmpeg

--- a/ffmpeg/test_setup.py
+++ b/ffmpeg/test_setup.py
@@ -1,0 +1,84 @@
+"""Run with python3 ffmpeg/test_setup.py; no SDK downloads or native compilation."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import tarfile
+
+
+def executable(path, body):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('#!/bin/bash\nset -eu\n' + body)
+    path.chmod(0o755)
+
+
+with tempfile.TemporaryDirectory(prefix='nextlib setup ') as temp:
+    root = Path(temp)
+    ffmpeg = root / 'ffmpeg'
+    ffmpeg.mkdir()
+    shutil.copy(Path(__file__).with_name('setup.sh'), ffmpeg)
+    for name in ('mbedtls-3.4.1', 'libvpx-1.13.0', 'ffmpeg-6.0'):
+        (ffmpeg / 'sources' / name).mkdir(parents=True)
+    # Partial previous builds must not suppress a retry.
+    (ffmpeg / 'build').mkdir()
+    (ffmpeg / 'output').mkdir()
+    sdk = root / 'android sdk'
+    host = 'darwin-x86_64' if os.uname().sysname == 'Darwin' else 'linux-x86_64'
+    clang = sdk / 'ndk/test-ndk/toolchains/llvm/prebuilt' / host / 'bin/clang'
+    cmake = sdk / 'cmake/test-cmake/bin/cmake'
+    cli = root / 'android cli'
+    log = root / 'cli.log'
+    executable(cli, 'printf "%s\\n" "$@" > "$CLI_LOG"\nexit 19\n')
+    executable(root / 'bin/pkg-config', 'exit 0\n')
+    env = dict(os.environ, PATH=str(root / 'bin') + os.pathsep + os.environ['PATH'], ANDROID_HOME=str(sdk), ANDROID_CLI=str(cli),
+               ANDROID_NDK_VERSION='test-ndk', ANDROID_CMAKE_VERSION='test-cmake',
+               CLI_LOG=str(log))
+
+    def run():
+        return subprocess.run(['bash', str(ffmpeg / 'setup.sh')], env=env,
+                              capture_output=True, text=True)
+
+    assert run().returncode == 19, 'CLI install failures must propagate'
+    assert log.read_text().splitlines() == [f'--sdk={sdk}', 'sdk', 'install',
+                                           'ndk/test-ndk', 'cmake/test-cmake']
+    executable(clang, 'exit 0\n')
+    assert run().returncode == 19
+    assert log.read_text().splitlines()[-1:] == ['cmake/test-cmake']
+    assert 'ndk/test-ndk' not in log.read_text().splitlines()
+    executable(cli, 'exit 0\n')
+    result = run()
+    assert result.returncode != 0 and 'installation is incomplete' in result.stderr
+    # Stop at the first native build step; installed tools must avoid the CLI.
+    executable(cmake, 'echo native-build-reached >&2\nexit 42\n')
+    log.unlink()
+    result = run()
+    assert result.returncode == 42 and 'native-build-reached' in result.stderr, result
+    assert not log.exists()
+    source = ffmpeg / 'sources/mbedtls-3.4.1'
+    shutil.rmtree(source)
+    executable(root / 'bin/curl', 'exit 22\n')
+    result = run()
+    assert result.returncode == 22 and not source.exists()
+    assert not list((ffmpeg / 'sources').glob('.download.*'))
+    archive = root / 'source.tar.gz'
+    with tarfile.open(archive, 'w:gz') as tar:
+        directory = tarfile.TarInfo('mbedtls-3.4.1')
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o755
+        tar.addfile(directory)
+    env['SOURCE_ARCHIVE'] = str(archive)
+    executable(root / 'bin/curl', 'cp "$SOURCE_ARCHIVE" "${@: -1}"\n')
+    result = run()
+    assert result.returncode == 42 and source.is_dir(), result
+    assert not list((ffmpeg / 'sources').glob('.download.*'))
+    cmake.unlink()
+    env['ANDROID_CLI'] = str(root / 'missing-cli')
+    result = run()
+    assert result.returncode != 0 and 'Install Android CLI' in result.stderr
+    env.pop('ANDROID_HOME')
+    env.pop('ANDROID_SDK_ROOT', None)
+    result = run()
+    assert result.returncode != 0 and 'Set ANDROID_HOME' in result.stderr
+
+print('Setup checks passed')

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,0 @@
-jdk:
-  - openjdk8
-before_install:
-  - yes | sdkmanager "cmake;3.22.1"
-  - sdk install java 17.0.8-tem
-  - sdk use java 17.0.8-tem

--- a/media3ext/build.gradle.kts
+++ b/media3ext/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.android.build.gradle.internal.tasks.factory.dependsOn
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -45,17 +44,11 @@ android {
     }
 }
 
-// Gradle task to setup ffmpeg
-val ffmpegSetup by tasks.registering(Exec::class) {
-    workingDir = file("../ffmpeg")
-    // export ndk path and run bash script
-    environment("ANDROID_SDK_HOME", androidComponents.sdkComponents.sdkDirectory.get().asFile.absolutePath)
-    environment("ANDROID_NDK_HOME", androidComponents.sdkComponents.ndkDirectory.get().asFile.absolutePath)
-    environment("ANDROID_CMAKE_VERSION", libs.versions.cmake.get())
-    commandLine("bash", "setup.sh")
+tasks.configureEach {
+    if (name == "preBuild" || name.startsWith("configureCMake") || name.startsWith("buildCMake")) {
+        dependsOn(":ffmpegSetup")
+    }
 }
-
-tasks.preBuild.dependsOn(ffmpegSetup)
 
 dependencies {
     implementation(libs.androidx.media3.exoplayer)

--- a/mediainfo/build.gradle.kts
+++ b/mediainfo/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.android.build.gradle.internal.tasks.factory.dependsOn
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -45,17 +44,11 @@ android {
     }
 }
 
-// Gradle task to setup ffmpeg
-val ffmpegSetup by tasks.registering(Exec::class) {
-    workingDir = file("../ffmpeg")
-    // export ndk path and run bash script
-    environment("ANDROID_SDK_HOME", androidComponents.sdkComponents.sdkDirectory.get().asFile.absolutePath)
-    environment("ANDROID_NDK_HOME", androidComponents.sdkComponents.ndkDirectory.get().asFile.absolutePath)
-    environment("ANDROID_CMAKE_VERSION", libs.versions.cmake.get())
-    commandLine("bash", "setup.sh")
+tasks.configureEach {
+    if (name == "preBuild" || name.startsWith("configureCMake") || name.startsWith("buildCMake")) {
+        dependsOn(":ffmpegSetup")
+    }
 }
-
-//tasks.preBuild.dependsOn(ffmpegSetup)
 
 dependencies {
     implementation(libs.androidx.annotation)


### PR DESCRIPTION
Replace deprecated sdkmanager usage with Android CLI and make both Android modules depend on one shared FFmpeg setup task. Gradle tracks the script, tool versions, and generated output, preventing duplicate parallel builds and allowing retries after failed setup.

The script installs missing pinned NDK/CMake packages, fails promptly on errors, stages source downloads before extraction is published, and prefers native yasm on Apple Silicon. CI installs Android CLI and runs setup regression checks. Update source-build instructions and remove JitPack configuration.

Validation:
- Both modules' debug builds passed with parallel execution; both AARs contain native libraries for all four ABIs.
- Repeat build passed in 470 ms with `:ffmpegSetup UP-TO-DATE`.
- Setup regression checks, Bash syntax, and whitespace checks passed.
- Gradle dry runs passed with configuration-cache reuse.
