### PR TITLE
Fix FFmpeg surface colors and avoid copied output frames

### DIFF
--- a/media3ext/src/main/cpp/ffvideo.cpp
+++ b/media3ext/src/main/cpp/ffvideo.cpp
@@ -4,6 +4,8 @@
 #include <cstdlib>
 #include <android/native_window_jni.h>
 #include <algorithm>
+#include <array>
+#include <climits>
 #include <cstring>
 #include <memory>
 #include "ffcommon.h"
@@ -72,10 +74,66 @@ static const int VIDEO_DECODER_ERROR_READ_FRAME = -3;
 // Media3 C.VIDEO_OUTPUT_MODE_SURFACE_YUV.
 constexpr int kOutputModeSurface = 1;
 
+// Media3's GL renderer uses BT.709 when the matrix is unknown.
+static int GetOutputColorspace(AVColorSpace colorspace) {
+    switch (colorspace) {
+        case AVCOL_SPC_BT709: return 2;
+        case AVCOL_SPC_BT470BG:
+        case AVCOL_SPC_SMPTE170M: return 1;
+        case AVCOL_SPC_BT2020_NCL: return 3;
+        default: return 0;
+    }
+}
+
+struct ScaleContext {
+    ~ScaleContext() { sws_freeContext(context); }
+
+    SwsContext *Get(const AVFrame *frame, AVPixelFormat output_format) {
+        const int colorspace = GetOutputColorspace(frame->colorspace);
+        const int matrix = colorspace == 1 ? SWS_CS_ITU601 :
+                colorspace == 3 ? SWS_CS_BT2020 : SWS_CS_ITU709;
+        const int full_range = frame->color_range == AVCOL_RANGE_JPEG;
+        const std::array<int, 6> configuration = {frame->width, frame->height,
+                frame->format, output_format, matrix, full_range};
+        if (context && configuration == cached_configuration) return context;
+
+        sws_freeContext(context);
+        context = sws_alloc_context();
+        if (!context) return nullptr;
+        const int *coefficients = sws_getCoefficients(matrix);
+        // Range must be set BEFORE initialization: otherwise swscale can choose an
+        // unscaled planar copy that ignores a subsequent full-to-limited range change.
+        if (av_opt_set_int(context, "srcw", frame->width, 0) < 0 ||
+            av_opt_set_int(context, "srch", frame->height, 0) < 0 ||
+            av_opt_set_int(context, "src_format", frame->format, 0) < 0 ||
+            av_opt_set_int(context, "dstw", frame->width, 0) < 0 ||
+            av_opt_set_int(context, "dsth", frame->height, 0) < 0 ||
+            av_opt_set_int(context, "dst_format", output_format, 0) < 0 ||
+            av_opt_set_int(context, "sws_flags", SWS_BILINEAR, 0) < 0 ||
+            sws_setColorspaceDetails(context, coefficients, full_range, coefficients,
+                    output_format == AV_PIX_FMT_RGBA, 0, 1 << 16, 1 << 16) < 0 ||
+            sws_init_context(context, nullptr, nullptr) < 0) {
+            sws_freeContext(context);
+            context = nullptr;
+        }
+        cached_configuration = configuration;
+        return context;
+    }
+
+    SwsContext *context{};
+    std::array<int, 6> cached_configuration{};
+};
+
+// Surface::disconnect clears its buffer slots. Unlocking afterwards releases the
+// CPU mapping, but queueBuffer rejects the removed slot instead of displaying it.
+// The public NDK has no unlock-without-post operation.
+static void DiscardLockedBuffer(ANativeWindow *window) {
+    native_window_api_disconnect(window, NATIVE_WINDOW_API_CPU);
+    ANativeWindow_unlockAndPost(window);
+}
+
 struct JniContext {
     ~JniContext() {
-        sws_freeContext(renderContext);
-        sws_freeContext(yuvContext);
         releaseContext(codecContext);
     }
 
@@ -115,8 +173,8 @@ struct JniContext {
 
     AVCodecContext *codecContext{};
     // Decoding and rendering run on different threads.
-    SwsContext *renderContext{};
-    SwsContext *yuvContext{};
+    ScaleContext renderContext;
+    ScaleContext yuvContext;
 
     ANativeWindow *native_window = nullptr;
     jobject surface = nullptr;
@@ -221,21 +279,6 @@ Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpe
     av_frame_free(&frame);
 }
 
-// Convert using metadata from this frame, not the decoder's next queued frame.
-static SwsContext *GetScaleContext(SwsContext *context, const AVFrame *frame,
-                                   AVPixelFormat output_format) {
-    context = sws_getCachedContext(context, frame->width, frame->height,
-            static_cast<AVPixelFormat>(frame->format), frame->width, frame->height,
-            output_format, SWS_BILINEAR, nullptr, nullptr, nullptr);
-    if (context) {
-        const int *coefficients = sws_getCoefficients(
-                frame->colorspace == AVCOL_SPC_UNSPECIFIED ? SWS_CS_DEFAULT : frame->colorspace);
-        sws_setColorspaceDetails(context, coefficients, frame->color_range == AVCOL_RANGE_JPEG,
-                coefficients, output_format == AV_PIX_FMT_RGBA, 0, 1 << 16, 1 << 16);
-    }
-    return context;
-}
-
 extern "C"
 JNIEXPORT jint JNICALL
 Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpegRenderFrame(JNIEnv *env,
@@ -263,8 +306,8 @@ Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpe
         jniContext->native_window_width = frame->width;
         jniContext->native_window_height = frame->height;
     }
-    jniContext->renderContext = GetScaleContext(jniContext->renderContext, frame, AV_PIX_FMT_RGBA);
-    if (!jniContext->renderContext) return VIDEO_DECODER_ERROR_OTHER;
+    SwsContext *scaleContext = jniContext->renderContext.Get(frame, AV_PIX_FMT_RGBA);
+    if (!scaleContext) return VIDEO_DECODER_ERROR_OTHER;
 
     ANativeWindow_Buffer buffer;
     int result = ANativeWindow_lock(jniContext->native_window, &buffer, nullptr);
@@ -277,14 +320,21 @@ Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpe
 
     int rows = 0;
     if (buffer.bits && buffer.format == WINDOW_FORMAT_RGBA_8888 &&
-        buffer.width >= frame->width && buffer.height >= frame->height) {
+        buffer.width >= frame->width && buffer.height >= frame->height &&
+        buffer.stride >= buffer.width && buffer.stride <= INT_MAX / 4) {
         uint8_t *dest[] = {static_cast<uint8_t *>(buffer.bits), nullptr, nullptr, nullptr};
         int strides[] = {buffer.stride * 4, 0, 0, 0};
-        rows = sws_scale(jniContext->renderContext, frame->data, frame->linesize,
+        rows = sws_scale(scaleContext, frame->data, frame->linesize,
                         0, frame->height, dest, strides);
     }
+    if (rows != frame->height) {
+        DiscardLockedBuffer(jniContext->native_window);
+        jniContext->connected_as_cpu = false;
+        jniContext->ReleaseSurface(env);
+        return VIDEO_DECODER_ERROR_OTHER;
+    }
     result = ANativeWindow_unlockAndPost(jniContext->native_window);
-    return !result && rows == frame->height ? VIDEO_DECODER_SUCCESS : VIDEO_DECODER_ERROR_OTHER;
+    return !result ? VIDEO_DECODER_SUCCESS : VIDEO_DECODER_ERROR_OTHER;
 }
 
 extern "C"
@@ -382,8 +432,7 @@ Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpe
     // Media3's YUV output contract is always planar 8-bit 4:2:0, even for 10-bit/4:4:4 input.
     const int yStride = ALIGN(frame->width, 32);
     const int uvStride = ALIGN((frame->width + 1) / 2, 16);
-    const int colorspace = frame->colorspace == AVCOL_SPC_BT709 ? 2 :
-            frame->colorspace == AVCOL_SPC_BT2020_NCL ? 3 : 1;
+    const int colorspace = GetOutputColorspace(frame->colorspace);
     const jboolean initialized = env->CallBooleanMethod(output_buffer,
             jniContext->init_for_yuv_frame_method, frame->width, frame->height,
             yStride, uvStride, colorspace);
@@ -397,8 +446,8 @@ Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpe
     const size_t uvLength = static_cast<size_t>(uvStride) * ((frame->height + 1) / 2);
     uint8_t *dest[] = {data, data + yLength, data + yLength + uvLength, nullptr};
     int strides[] = {yStride, uvStride, uvStride, 0};
-    jniContext->yuvContext = GetScaleContext(jniContext->yuvContext, frame, AV_PIX_FMT_YUV420P);
-    result = jniContext->yuvContext ? sws_scale(jniContext->yuvContext, frame->data,
+    SwsContext *scaleContext = jniContext->yuvContext.Get(frame, AV_PIX_FMT_YUV420P);
+    result = scaleContext ? sws_scale(scaleContext, frame->data,
             frame->linesize, 0, frame->height, dest, strides) : 0;
     const bool success = result == frame->height;
     av_frame_free(&frame);

--- a/media3ext/src/main/cpp/ffvideo.cpp
+++ b/media3ext/src/main/cpp/ffvideo.cpp
@@ -127,9 +127,10 @@ struct ScaleContext {
 // Surface::disconnect clears its buffer slots. Unlocking afterwards releases the
 // CPU mapping, but queueBuffer rejects the removed slot instead of displaying it.
 // The public NDK has no unlock-without-post operation.
-static void DiscardLockedBuffer(ANativeWindow *window) {
-    native_window_api_disconnect(window, NATIVE_WINDOW_API_CPU);
+static int DiscardLockedBuffer(ANativeWindow *window) {
+    const int result = native_window_api_disconnect(window, NATIVE_WINDOW_API_CPU);
     ANativeWindow_unlockAndPost(window);
+    return result;
 }
 
 struct JniContext {
@@ -328,8 +329,7 @@ Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpe
                         0, frame->height, dest, strides);
     }
     if (rows != frame->height) {
-        DiscardLockedBuffer(jniContext->native_window);
-        jniContext->connected_as_cpu = false;
+        jniContext->connected_as_cpu = DiscardLockedBuffer(jniContext->native_window) != 0;
         jniContext->ReleaseSurface(env);
         return VIDEO_DECODER_ERROR_OTHER;
     }

--- a/media3ext/src/main/cpp/ffvideo.cpp
+++ b/media3ext/src/main/cpp/ffvideo.cpp
@@ -4,6 +4,8 @@
 #include <cstdlib>
 #include <android/native_window_jni.h>
 #include <algorithm>
+#include <cstring>
+#include <memory>
 #include "ffcommon.h"
 
 extern "C" {
@@ -67,57 +69,54 @@ static const int VIDEO_DECODER_ERROR_OTHER = -2;
 static const int VIDEO_DECODER_ERROR_READ_FRAME = -3;
 
 
-// YUV plane indices.
-const int kPlaneY = 0;
-const int kPlaneU = 1;
-const int kPlaneV = 2;
-const int kMaxPlanes = 3;
-
-// Android YUV format. See:
-// https://developer.android.com/reference/android/graphics/ImageFormat.html#YV12.
-const int kImageFormatYV12 = 0x32315659;
+// Media3 C.VIDEO_OUTPUT_MODE_SURFACE_YUV.
+constexpr int kOutputModeSurface = 1;
 
 struct JniContext {
     ~JniContext() {
+        sws_freeContext(renderContext);
+        sws_freeContext(yuvContext);
+        releaseContext(codecContext);
+    }
+
+    void ReleaseSurface(JNIEnv *env) {
         if (native_window) {
             if (connected_as_cpu) {
                 native_window_api_disconnect(native_window, NATIVE_WINDOW_API_CPU);
             }
             ANativeWindow_release(native_window);
         }
+        if (surface) env->DeleteGlobalRef(surface);
+        native_window = nullptr;
+        surface = nullptr;
+        connected_as_cpu = false;
+        native_window_width = 0;
+        native_window_height = 0;
     }
 
     bool MaybeAcquireNativeWindow(JNIEnv *env, jobject new_surface) {
-        if (surface == new_surface) {
-            return true;
-        }
-        if (native_window) {
-            if (connected_as_cpu) {
-                native_window_api_disconnect(native_window, NATIVE_WINDOW_API_CPU);
-                connected_as_cpu = false;
-            }
-            ANativeWindow_release(native_window);
-        }
-        native_window_width = 0;
-        native_window_height = 0;
+        if (surface && env->IsSameObject(surface, new_surface)) return true;
+        ReleaseSurface(env);
         native_window = ANativeWindow_fromSurface(env, new_surface);
-        if (native_window == nullptr) {
-            LOGE("kJniStatusANativeWindowError");
-            surface = nullptr;
+        if (!native_window) return false;
+        surface = env->NewGlobalRef(new_surface);
+        if (!surface) {
+            ReleaseSurface(env);
             return false;
         }
-        surface = new_surface;
         return true;
     }
 
     jfieldID data_field{};
-    jfieldID yuvPlanes_field{};
-    jfieldID yuvStrides_field{};
+    jfieldID decoder_private_field{};
+    jmethodID init_for_private_frame_method{};
     jmethodID init_for_yuv_frame_method{};
     jmethodID init_method{};
 
     AVCodecContext *codecContext{};
-    SwsContext *swsContext{};
+    // Decoding and rendering run on different threads.
+    SwsContext *renderContext{};
+    SwsContext *yuvContext{};
 
     ANativeWindow *native_window = nullptr;
     jobject surface = nullptr;
@@ -130,7 +129,7 @@ JniContext *createVideoContext(JNIEnv *env,
                                AVCodec *codec,
                                jbyteArray extraData,
                                jint threads) {
-    auto *jniContext = new JniContext();
+    auto jniContext = std::make_unique<JniContext>();
 
     AVCodecContext *codecContext = avcodec_alloc_context3(codec);
     if (!codecContext) {
@@ -138,13 +137,14 @@ JniContext *createVideoContext(JNIEnv *env,
         return nullptr;
     }
 
+    jniContext->codecContext = codecContext;
+
     if (extraData) {
         jsize size = env->GetArrayLength(extraData);
         codecContext->extradata_size = size;
-        codecContext->extradata = (uint8_t *) av_malloc(size + AV_INPUT_BUFFER_PADDING_SIZE);
+        codecContext->extradata = (uint8_t *) av_mallocz(size + AV_INPUT_BUFFER_PADDING_SIZE);
         if (!codecContext->extradata) {
             LOGE("Failed to allocate extradata.");
-            releaseContext(codecContext);
             return nullptr;
         }
         env->GetByteArrayRegion(extraData, 0, size, (jbyte *) codecContext->extradata);
@@ -155,21 +155,19 @@ JniContext *createVideoContext(JNIEnv *env,
     int result = avcodec_open2(codecContext, codec, nullptr);
     if (result < 0) {
         logError("avcodec_open2", result);
-        releaseContext(codecContext);
         return nullptr;
     }
-
-    jniContext->codecContext = codecContext;
 
     // Populate JNI References.
     jclass outputBufferClass = env->FindClass("androidx/media3/decoder/VideoDecoderOutputBuffer");
     jniContext->data_field = env->GetFieldID(outputBufferClass, "data", "Ljava/nio/ByteBuffer;");
-    jniContext->yuvStrides_field = env->GetFieldID(outputBufferClass, "yuvStrides", "[I");
-    jniContext->yuvPlanes_field = env->GetFieldID(outputBufferClass, "yuvPlanes", "[Ljava/nio/ByteBuffer;");
+    jniContext->decoder_private_field = env->GetFieldID(outputBufferClass, "decoderPrivate", "J");
+    jniContext->init_for_private_frame_method = env->GetMethodID(outputBufferClass, "initForPrivateFrame", "(II)V");
     jniContext->init_for_yuv_frame_method = env->GetMethodID(outputBufferClass, "initForYuvFrame", "(IIIII)Z");
     jniContext->init_method = env->GetMethodID(outputBufferClass, "init", "(JILjava/nio/ByteBuffer;)V");
 
-    return jniContext;
+    if (env->ExceptionCheck()) return nullptr;
+    return jniContext.release();
 }
 
 
@@ -209,12 +207,33 @@ JNIEXPORT void JNICALL
 Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpegRelease(JNIEnv *env, jobject thiz,
                                                                               jlong jContext) {
     auto *const jniContext = reinterpret_cast<JniContext *>(jContext);
-    AVCodecContext *context = jniContext->codecContext;
-    if (context) {
-        sws_freeContext(jniContext->swsContext);
-        releaseContext(context);
+    if (jniContext) {
+        jniContext->ReleaseSurface(env);
         delete jniContext;
     }
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpegReleaseFrame(
+        JNIEnv *, jobject, jlong frame_pointer) {
+    auto *frame = reinterpret_cast<AVFrame *>(frame_pointer);
+    av_frame_free(&frame);
+}
+
+// Convert using metadata from this frame, not the decoder's next queued frame.
+static SwsContext *GetScaleContext(SwsContext *context, const AVFrame *frame,
+                                   AVPixelFormat output_format) {
+    context = sws_getCachedContext(context, frame->width, frame->height,
+            static_cast<AVPixelFormat>(frame->format), frame->width, frame->height,
+            output_format, SWS_BILINEAR, nullptr, nullptr, nullptr);
+    if (context) {
+        const int *coefficients = sws_getCoefficients(
+                frame->colorspace == AVCOL_SPC_UNSPECIFIED ? SWS_CS_DEFAULT : frame->colorspace);
+        sws_setColorspaceDetails(context, coefficients, frame->color_range == AVCOL_RANGE_JPEG,
+                coefficients, output_format == AV_PIX_FMT_RGBA, 0, 1 << 16, 1 << 16);
+    }
+    return context;
 }
 
 extern "C"
@@ -227,114 +246,45 @@ Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpe
                                                                                   jint displayed_width,
                                                                                   jint displayed_height) {
     auto *const jniContext = reinterpret_cast<JniContext *>(jContext);
-    if (!jniContext->MaybeAcquireNativeWindow(env, surface)) {
+    auto *frame = reinterpret_cast<AVFrame *>(
+            env->GetLongField(output_buffer, jniContext->decoder_private_field));
+    if (!frame || !jniContext->MaybeAcquireNativeWindow(env, surface)) {
         return VIDEO_DECODER_ERROR_OTHER;
     }
 
-    if (jniContext->native_window_width != displayed_width ||
-        jniContext->native_window_height != displayed_height) {
-
-        if (ANativeWindow_setBuffersGeometry(
-                jniContext->native_window,
-                displayed_width,
-                displayed_height,
-                kImageFormatYV12)) {
-            LOGE("kJniStatusANativeWindowError");
+    if (jniContext->native_window_width != frame->width ||
+        jniContext->native_window_height != frame->height) {
+        // RGBA is a public NDK window format; YV12 CPU buffers are not portable
+        // across Surface producers (including the emulator's graphics backend).
+        if (ANativeWindow_setBuffersGeometry(jniContext->native_window,
+                frame->width, frame->height, WINDOW_FORMAT_RGBA_8888)) {
             return VIDEO_DECODER_ERROR_OTHER;
         }
-
-        jniContext->native_window_width = displayed_width;
-        jniContext->native_window_height = displayed_height;
-
-        // Initializing swsContext with AV_PIX_FMT_YUV420P, which is equivalent to YV12.
-        // The only difference is the order of the u and v planes.
-        SwsContext *swsContext = sws_getContext(displayed_width, displayed_height,
-                                                jniContext->codecContext->pix_fmt,
-                                                displayed_width, displayed_height,
-                                                AV_PIX_FMT_YUV420P,
-                                                SWS_BILINEAR, nullptr, nullptr, nullptr);
-
-        if (!swsContext) {
-            LOGE("Failed to allocate swsContext.");
-            return VIDEO_DECODER_ERROR_OTHER;
-        }
-        jniContext->swsContext = swsContext;
+        jniContext->native_window_width = frame->width;
+        jniContext->native_window_height = frame->height;
     }
+    jniContext->renderContext = GetScaleContext(jniContext->renderContext, frame, AV_PIX_FMT_RGBA);
+    if (!jniContext->renderContext) return VIDEO_DECODER_ERROR_OTHER;
 
-    ANativeWindow_Buffer native_window_buffer;
-    int result = ANativeWindow_lock(jniContext->native_window, &native_window_buffer, nullptr);
+    ANativeWindow_Buffer buffer;
+    int result = ANativeWindow_lock(jniContext->native_window, &buffer, nullptr);
     if (result == -19) {
-        jniContext->surface = nullptr;
+        jniContext->ReleaseSurface(env);
         return VIDEO_DECODER_SUCCESS;
-    } else if (result || native_window_buffer.bits == nullptr) {
-        LOGE("kJniStatusANativeWindowError");
-        return VIDEO_DECODER_ERROR_OTHER;
     }
-    // A successful lock connects the native window to the CPU producer API.
+    if (result) return VIDEO_DECODER_ERROR_OTHER;
     jniContext->connected_as_cpu = true;
 
-    // source planes from VideoDecoderOutputBuffer
-    jobject yuvPlanes_object = env->GetObjectField(output_buffer, jniContext->yuvPlanes_field);
-    auto yuvPlanes_array = jobjectArray(yuvPlanes_object);
-    jobject yuvPlanesY = env->GetObjectArrayElement(yuvPlanes_array, kPlaneY);
-    jobject yuvPlanesU = env->GetObjectArrayElement(yuvPlanes_array, kPlaneU);
-    jobject yuvPlanesV = env->GetObjectArrayElement(yuvPlanes_array, kPlaneV);
-
-    auto *planeY = reinterpret_cast<uint8_t *>(env->GetDirectBufferAddress(yuvPlanesY));
-    auto *planeU = reinterpret_cast<uint8_t *>(env->GetDirectBufferAddress(yuvPlanesU));
-    auto *planeV = reinterpret_cast<uint8_t *>(env->GetDirectBufferAddress(yuvPlanesV));
-
-    // source strides from VideoDecoderOutputBuffer
-    jobject yuvStrides_object = env->GetObjectField(output_buffer, jniContext->yuvStrides_field);
-    auto *yuvStrides_array = reinterpret_cast<jintArray *>(&yuvStrides_object);
-    int *yuvStrides = env->GetIntArrayElements(*yuvStrides_array, nullptr);
-
-    int strideY = yuvStrides[kPlaneY];
-    int strideU = yuvStrides[kPlaneU];
-    int strideV = yuvStrides[kPlaneV];
-
-
-    const int32_t native_window_buffer_uv_height = (native_window_buffer.height + 1) / 2;
-    auto native_window_buffer_bits = reinterpret_cast<uint8_t *>(native_window_buffer.bits);
-    const int native_window_buffer_uv_stride = ALIGN(native_window_buffer.stride / 2, 16);
-    const int v_plane_height = std::min(native_window_buffer_uv_height, displayed_height);
-
-    const int y_plane_size = native_window_buffer.stride * native_window_buffer.height;
-    const int v_plane_size = v_plane_height * native_window_buffer_uv_stride;
-
-    // source data
-    uint8_t *src[3] = {planeY, planeU, planeV};
-
-    // source strides
-    int src_stride[3] = {strideY, strideU, strideV};
-
-    // destination data with u and v swapped
-    uint8_t *dest[3] = {native_window_buffer_bits,
-                        native_window_buffer_bits + y_plane_size + v_plane_size,
-                        native_window_buffer_bits + y_plane_size};
-
-    // destination strides
-    int dest_stride[3] = {native_window_buffer.stride,
-                          native_window_buffer_uv_stride,
-                          native_window_buffer_uv_stride};
-
-
-    //Perform color space conversion using sws_scale.
-    //Convert the source data (src) with specified strides (src_stride) and displayed height,
-    //and store the result in the destination data (dest) with corresponding strides (dest_stride).
-    sws_scale(jniContext->swsContext,
-              src, src_stride,
-              0, displayed_height,
-              dest, dest_stride);
-
-    env->ReleaseIntArrayElements(*yuvStrides_array, yuvStrides, 0);
-
-    if (ANativeWindow_unlockAndPost(jniContext->native_window)) {
-        LOGE("kJniStatusANativeWindowError");
-        return VIDEO_DECODER_ERROR_OTHER;
+    int rows = 0;
+    if (buffer.bits && buffer.format == WINDOW_FORMAT_RGBA_8888 &&
+        buffer.width >= frame->width && buffer.height >= frame->height) {
+        uint8_t *dest[] = {static_cast<uint8_t *>(buffer.bits), nullptr, nullptr, nullptr};
+        int strides[] = {buffer.stride * 4, 0, 0, 0};
+        rows = sws_scale(jniContext->renderContext, frame->data, frame->linesize,
+                        0, frame->height, dest, strides);
     }
-
-    return VIDEO_DECODER_SUCCESS;
+    result = ANativeWindow_unlockAndPost(jniContext->native_window);
+    return !result && rows == frame->height ? VIDEO_DECODER_SUCCESS : VIDEO_DECODER_ERROR_OTHER;
 }
 
 extern "C"
@@ -349,7 +299,14 @@ Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpe
     AVCodecContext *avContext = jniContext->codecContext;
 
     auto *inputBuffer = (uint8_t *) env->GetDirectBufferAddress(encoded_data);
-    AVPacket packet = *av_packet_alloc();
+    if (!inputBuffer || length < 0 ||
+        env->GetDirectBufferCapacity(encoded_data) < static_cast<jlong>(length) + AV_INPUT_BUFFER_PADDING_SIZE) {
+        return VIDEO_DECODER_ERROR_OTHER;
+    }
+    memset(inputBuffer + length, 0, AV_INPUT_BUFFER_PADDING_SIZE);
+    AVPacket packet{};
+    packet.dts = AV_NOPTS_VALUE;
+    packet.pos = -1;
     packet.data = inputBuffer;
     packet.size = length;
     packet.pts = input_time;
@@ -403,38 +360,47 @@ Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpe
         return VIDEO_DECODER_ERROR_OTHER;
     }
 
-    // success
-    // init time and mode
     env->CallVoidMethod(output_buffer, jniContext->init_method, frame->pts, output_mode, nullptr);
-
-    // init data
-    const jboolean init_result = env->CallBooleanMethod(
-            output_buffer, jniContext->init_for_yuv_frame_method,
-            frame->width,
-            frame->height,
-            frame->linesize[0], frame->linesize[1],
-            0);
     if (env->ExceptionCheck()) {
-        // Exception is thrown in Java when returning from the native call.
+        av_frame_free(&frame);
         return VIDEO_DECODER_ERROR_OTHER;
     }
-    if (!init_result) {
-        return VIDEO_DECODER_ERROR_OTHER;
+    if (output_mode == kOutputModeSurface) {
+        env->CallVoidMethod(output_buffer, jniContext->init_for_private_frame_method,
+                           frame->width, frame->height);
+        if (env->ExceptionCheck()) {
+            av_frame_free(&frame);
+            return VIDEO_DECODER_ERROR_OTHER;
+        }
+        // The output buffer owns this reference until it is rendered, dropped or flushed.
+        // Preserve the actual planes, bit depth and color metadata without a full-frame copy.
+        env->SetLongField(output_buffer, jniContext->decoder_private_field,
+                          reinterpret_cast<jlong>(frame));
+        return VIDEO_DECODER_SUCCESS;
     }
 
+    // Media3's YUV output contract is always planar 8-bit 4:2:0, even for 10-bit/4:4:4 input.
+    const int yStride = ALIGN(frame->width, 32);
+    const int uvStride = ALIGN((frame->width + 1) / 2, 16);
+    const int colorspace = frame->colorspace == AVCOL_SPC_BT709 ? 2 :
+            frame->colorspace == AVCOL_SPC_BT2020_NCL ? 3 : 1;
+    const jboolean initialized = env->CallBooleanMethod(output_buffer,
+            jniContext->init_for_yuv_frame_method, frame->width, frame->height,
+            yStride, uvStride, colorspace);
+    if (env->ExceptionCheck() || !initialized) {
+        av_frame_free(&frame);
+        return VIDEO_DECODER_ERROR_OTHER;
+    }
     jobject data_object = env->GetObjectField(output_buffer, jniContext->data_field);
-    auto *data = reinterpret_cast<jbyte *>(env->GetDirectBufferAddress(data_object));
-    const int32_t uvHeight = (frame->height + 1) / 2;
-    const uint64_t yLength = frame->linesize[0] * frame->height;
-    const uint64_t uvLength = frame->linesize[1] * uvHeight;
-
-    // TODO: Support rotate YUV data
-
-    memcpy(data, frame->data[0], yLength);
-    memcpy(data + yLength, frame->data[1], uvLength);
-    memcpy(data + yLength + uvLength, frame->data[2], uvLength);
-
+    auto *data = static_cast<uint8_t *>(env->GetDirectBufferAddress(data_object));
+    const size_t yLength = static_cast<size_t>(yStride) * frame->height;
+    const size_t uvLength = static_cast<size_t>(uvStride) * ((frame->height + 1) / 2);
+    uint8_t *dest[] = {data, data + yLength, data + yLength + uvLength, nullptr};
+    int strides[] = {yStride, uvStride, uvStride, 0};
+    jniContext->yuvContext = GetScaleContext(jniContext->yuvContext, frame, AV_PIX_FMT_YUV420P);
+    result = jniContext->yuvContext ? sws_scale(jniContext->yuvContext, frame->data,
+            frame->linesize, 0, frame->height, dest, strides) : 0;
+    const bool success = result == frame->height;
     av_frame_free(&frame);
-
-    return result;
+    return success ? VIDEO_DECODER_SUCCESS : VIDEO_DECODER_ERROR_OTHER;
 }

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/FfmpegVideoDecoder.java
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/FfmpegVideoDecoder.java
@@ -15,6 +15,7 @@ import androidx.media3.decoder.SimpleDecoder;
 import androidx.media3.decoder.VideoDecoderOutputBuffer;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -25,8 +26,6 @@ final class FfmpegVideoDecoder extends
         SimpleDecoder<DecoderInputBuffer, VideoDecoderOutputBuffer, FfmpegDecoderException> {
 
     private static final String TAG = "FfmpegVideoDecoder";
-    // FFmpeg AV_INPUT_BUFFER_PADDING_SIZE; the native sender zeroes this padding.
-    private static final int INPUT_BUFFER_PADDING_SIZE = 64;
 
     // LINT.IfChange
     private static final int VIDEO_DECODER_SUCCESS = 0;
@@ -37,6 +36,9 @@ final class FfmpegVideoDecoder extends
 
     private final String codecName;
     private long nativeContext;
+    // Initialized by createOutputBuffer() during the SimpleDecoder constructor.
+    // Keep every buffer, including outputs held by a renderer during decoder reinitialization.
+    private List<VideoDecoderOutputBuffer> outputBuffers;
     @Nullable
     private final byte[] extraData;
     private Format format;
@@ -113,21 +115,30 @@ final class FfmpegVideoDecoder extends
 
     @Override
     protected DecoderInputBuffer createInputBuffer() {
-        return new DecoderInputBuffer(DecoderInputBuffer.BUFFER_REPLACEMENT_MODE_DIRECT, INPUT_BUFFER_PADDING_SIZE);
+        return new DecoderInputBuffer(DecoderInputBuffer.BUFFER_REPLACEMENT_MODE_DIRECT, FfmpegLibrary.getInputBufferPaddingSize());
     }
 
     @Override
     protected VideoDecoderOutputBuffer createOutputBuffer() {
-        return new VideoDecoderOutputBuffer(this::releaseOutputBuffer);
+        if (outputBuffers == null) outputBuffers = new ArrayList<>();
+        VideoDecoderOutputBuffer outputBuffer = new VideoDecoderOutputBuffer(this::releaseOutputBuffer);
+        outputBuffers.add(outputBuffer);
+        return outputBuffer;
     }
 
     @Override
     protected void releaseOutputBuffer(VideoDecoderOutputBuffer outputBuffer) {
+        synchronized (outputBuffers) {
+            releaseNativeFrame(outputBuffer);
+        }
+        super.releaseOutputBuffer(outputBuffer);
+    }
+
+    private void releaseNativeFrame(VideoDecoderOutputBuffer outputBuffer) {
         if (outputBuffer.decoderPrivate != 0) {
             ffmpegReleaseFrame(outputBuffer.decoderPrivate);
             outputBuffer.decoderPrivate = 0;
         }
-        super.releaseOutputBuffer(outputBuffer);
     }
 
     @Override
@@ -183,10 +194,15 @@ final class FfmpegVideoDecoder extends
     @Override
     public void release() {
         super.release();
-        // SimpleDecoder stops its thread but does not release queued output buffers.
-        flush();
-        ffmpegRelease(nativeContext);
-        nativeContext = 0;
+        // The decode thread has stopped. Reclaim queued and renderer-held frames together;
+        // clearing decoderPrivate also makes a later outputBuffer.release() harmless.
+        synchronized (outputBuffers) {
+            for (VideoDecoderOutputBuffer outputBuffer : outputBuffers) {
+                releaseNativeFrame(outputBuffer);
+            }
+            ffmpegRelease(nativeContext);
+            nativeContext = 0;
+        }
     }
 
     /**

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/FfmpegVideoDecoder.java
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/FfmpegVideoDecoder.java
@@ -25,6 +25,8 @@ final class FfmpegVideoDecoder extends
         SimpleDecoder<DecoderInputBuffer, VideoDecoderOutputBuffer, FfmpegDecoderException> {
 
     private static final String TAG = "FfmpegVideoDecoder";
+    // FFmpeg AV_INPUT_BUFFER_PADDING_SIZE; the native sender zeroes this padding.
+    private static final int INPUT_BUFFER_PADDING_SIZE = 64;
 
     // LINT.IfChange
     private static final int VIDEO_DECODER_SUCCESS = 0;
@@ -111,12 +113,21 @@ final class FfmpegVideoDecoder extends
 
     @Override
     protected DecoderInputBuffer createInputBuffer() {
-        return new DecoderInputBuffer(DecoderInputBuffer.BUFFER_REPLACEMENT_MODE_DIRECT);
+        return new DecoderInputBuffer(DecoderInputBuffer.BUFFER_REPLACEMENT_MODE_DIRECT, INPUT_BUFFER_PADDING_SIZE);
     }
 
     @Override
     protected VideoDecoderOutputBuffer createOutputBuffer() {
         return new VideoDecoderOutputBuffer(this::releaseOutputBuffer);
+    }
+
+    @Override
+    protected void releaseOutputBuffer(VideoDecoderOutputBuffer outputBuffer) {
+        if (outputBuffer.decoderPrivate != 0) {
+            ffmpegReleaseFrame(outputBuffer.decoderPrivate);
+            outputBuffer.decoderPrivate = 0;
+        }
+        super.releaseOutputBuffer(outputBuffer);
     }
 
     @Override
@@ -172,6 +183,8 @@ final class FfmpegVideoDecoder extends
     @Override
     public void release() {
         super.release();
+        // SimpleDecoder stops its thread but does not release queued output buffers.
+        flush();
         ffmpegRelease(nativeContext);
         nativeContext = 0;
     }
@@ -202,6 +215,8 @@ final class FfmpegVideoDecoder extends
     private native long ffmpegReset(long context);
 
     private native void ffmpegRelease(long context);
+
+    private native void ffmpegReleaseFrame(long frame);
 
     private native int ffmpegRenderFrame(
             long context, Surface surface, VideoDecoderOutputBuffer outputBuffer,

--- a/media3ext/src/test/cpp/ffvideo_test.cpp
+++ b/media3ext/src/test/cpp/ffvideo_test.cpp
@@ -1,0 +1,134 @@
+// Runs against the bundled FFmpeg and a real Android BufferQueue. No test framework required.
+#include <android/native_window_jni.h>
+#include <media/NdkImageReader.h>
+#include <cassert>
+#include <cstdio>
+
+static int invalidBuffer = 0;
+static int LockForTest(ANativeWindow *window, ANativeWindow_Buffer *buffer, ARect *dirty) {
+    int result = ANativeWindow_lock(window, buffer, dirty);
+    if (!result) {
+        switch (invalidBuffer) {
+            case 1: buffer->bits = nullptr; break;
+            case 2: buffer->format = WINDOW_FORMAT_RGB_565; break;
+            case 3: buffer->width = 1; break;
+            case 4: buffer->height = 1; break;
+            case 5: buffer->stride = 1; break;
+        }
+    }
+    return result;
+}
+
+// Inject only the returned lock metadata; allocation, locking, disconnect and posting are real.
+#define ANativeWindow_lock LockForTest
+#include "../../main/cpp/ffvideo.cpp"
+#undef ANativeWindow_lock
+
+static AVFrame *MakeFrame() {
+    AVFrame *frame = av_frame_alloc();
+    assert(frame);
+    frame->width = 128;
+    frame->height = 64;
+    frame->format = AV_PIX_FMT_YUV420P;
+    frame->colorspace = AVCOL_SPC_UNSPECIFIED;
+    frame->color_range = AVCOL_RANGE_MPEG;
+    assert(av_frame_get_buffer(frame, 32) == 0);
+    return frame;
+}
+
+static void Fill(AVFrame *frame, int y, int u, int v) {
+    const int values[] = {y, u, v};
+    for (int plane = 0; plane < 3; plane++) {
+        memset(frame->data[plane], values[plane], frame->linesize[plane] *
+                (plane == 0 ? frame->height : frame->height / 2));
+    }
+}
+
+static void CheckColorsAndRange() {
+    AVFrame *source = MakeFrame();
+    AVFrame *dest = MakeFrame();
+    ScaleContext scale;
+    // In particular, exercise YUV420P + JPEG range, not the deprecated YUVJ420P format.
+    for (AVColorRange range : {AVCOL_RANGE_MPEG, AVCOL_RANGE_JPEG, AVCOL_RANGE_MPEG}) {
+        source->color_range = range;
+        for (int white : {0, 1}) {
+            Fill(source, range == AVCOL_RANGE_JPEG ? (white ? 255 : 0) : (white ? 235 : 16), 128, 128);
+            SwsContext *context = scale.Get(source, AV_PIX_FMT_YUV420P);
+            assert(context && context == scale.Get(source, AV_PIX_FMT_YUV420P));
+            assert(sws_scale(context, source->data, source->linesize, 0, source->height,
+                    dest->data, dest->linesize) == source->height);
+            assert(dest->data[0][source->width / 2] == (white ? 235 : 16));
+        }
+    }
+    uint8_t rgba[128 * 64 * 4];
+    uint8_t *planes[] = {rgba, nullptr, nullptr, nullptr};
+    int strides[] = {128 * 4, 0, 0, 0};
+    for (AVColorSpace matrix : {AVCOL_SPC_UNSPECIFIED, AVCOL_SPC_BT709, AVCOL_SPC_SMPTE170M,
+                               AVCOL_SPC_BT709, AVCOL_SPC_UNSPECIFIED}) {
+        source->colorspace = matrix;
+        const bool bt601 = matrix == AVCOL_SPC_SMPTE170M;
+        Fill(source, bt601 ? 81 : 63, bt601 ? 90 : 102, 240);
+        SwsContext *context = scale.Get(source, AV_PIX_FMT_RGBA);
+        assert(context);
+        assert(sws_scale(context, source->data, source->linesize, 0, source->height,
+                planes, strides) == source->height);
+        assert(rgba[0] >= 250 && rgba[1] <= 4 && rgba[2] <= 4);
+        assert(GetOutputColorspace(matrix) == (bt601 ? 1 : matrix == AVCOL_SPC_BT709 ? 2 : 0));
+    }
+    av_frame_free(&source);
+    av_frame_free(&dest);
+    puts("PASS: unknown/BT.709/BT.601 matrices and full/limited range cache transitions");
+}
+
+static void CheckInvalidWindowBuffers() {
+    JNINativeInterface functions{};
+    functions.GetLongField = [](JNIEnv *, jobject buffer, jfieldID) -> jlong {
+        return reinterpret_cast<jlong>(buffer);
+    };
+    functions.IsSameObject = [](JNIEnv *, jobject a, jobject b) -> jboolean { return a == b; };
+    functions.DeleteGlobalRef = [](JNIEnv *, jobject) {};
+    JNIEnv env{&functions};
+    AVFrame *frame = MakeFrame();
+    Fill(frame, 63, 102, 240);
+    auto render = Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegVideoDecoder_ffmpegRenderFrame;
+    for (int fault = 1; fault <= 5; fault++) {
+        AImageReader *reader = nullptr;
+        assert(AImageReader_new(frame->width, frame->height, AIMAGE_FORMAT_RGBA_8888, 2, &reader) == AMEDIA_OK);
+        ANativeWindow *window = nullptr;
+        assert(AImageReader_getWindow(reader, &window) == AMEDIA_OK);
+        JniContext context;
+        auto surface = reinterpret_cast<jobject>(window);
+        context.surface = surface;
+        context.native_window = window;
+        ANativeWindow_acquire(window);
+        invalidBuffer = fault;
+        assert(render(&env, nullptr, reinterpret_cast<jlong>(&context), surface,
+                reinterpret_cast<jobject>(frame), frame->width, frame->height) == VIDEO_DECODER_ERROR_OTHER);
+        AImage *image = nullptr;
+        assert(AImageReader_acquireNextImage(reader, &image) == AMEDIA_IMGREADER_NO_BUFFER_AVAILABLE);
+        assert(context.native_window == nullptr);
+
+        // Reuse the same Surface after the error: it must be unlocked and reconnectable.
+        invalidBuffer = 0;
+        context.surface = surface;
+        context.native_window = window;
+        ANativeWindow_acquire(window);
+        assert(render(&env, nullptr, reinterpret_cast<jlong>(&context), surface,
+                reinterpret_cast<jobject>(frame), frame->width, frame->height) == VIDEO_DECODER_SUCCESS);
+        assert(AImageReader_acquireNextImage(reader, &image) == AMEDIA_OK);
+        uint8_t *pixels = nullptr;
+        int length = 0;
+        assert(AImage_getPlaneData(image, 0, &pixels, &length) == AMEDIA_OK);
+        assert(pixels[0] >= 250 && pixels[1] <= 4 && pixels[2] <= 4);
+        AImage_delete(image);
+        context.ReleaseSurface(&env);
+        AImageReader_delete(reader);
+    }
+    av_frame_free(&frame);
+    puts("PASS: five invalid buffer cases publish no image; same Surface renders after each error");
+}
+
+int main() {
+    CheckColorsAndRange();
+    CheckInvalidWindowBuffers();
+}

--- a/media3ext/src/test/cpp/run_ffvideo_test.sh
+++ b/media3ext/src/test/cpp/run_ffvideo_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# ARM64 Android API 26+ target; use a disposable emulator.
+set -euo pipefail
+: "${ANDROID_NDK_HOME:?Set ANDROID_NDK_HOME}"
+: "${ANDROID_SERIAL:?Set ANDROID_SERIAL to a disposable ARM64 emulator}"
+repo=$(cd "$(dirname "$0")/../../../.." && pwd)
+build=$(mktemp -d)
+trap 'rm -rf "$build"' EXIT
+compiler="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++"
+if [[ ! -x "$compiler" ]]; then
+    compiler="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++"
+fi
+"$compiler" --target=aarch64-linux-android26 -std=c++17 -O2 -static-libstdc++ \
+    -Wl,-z,max-page-size=16384 -I"$repo/ffmpeg/output/include/arm64-v8a" \
+    "$repo/media3ext/src/test/cpp/ffvideo_test.cpp" "$repo/media3ext/src/main/cpp/ffcommon.cpp" \
+    -L"$repo/ffmpeg/output/lib/arm64-v8a" -lavcodec -lavutil -lswscale -lswresample \
+    -landroid -lmediandk -llog -o "$build/ffvideo_test"
+adb shell mkdir -p /data/local/tmp/nextlib-ffvideo-test
+adb push "$build/ffvideo_test" "$repo"/ffmpeg/output/lib/arm64-v8a/*.so /data/local/tmp/nextlib-ffvideo-test/ >/dev/null
+adb shell 'cd /data/local/tmp/nextlib-ffvideo-test && LD_LIBRARY_PATH=. ./ffvideo_test'


### PR DESCRIPTION
FFmpeg software playback can produce green or incorrect colors through the YV12 CPU surface path. Retain each decoded AVFrame in Media3's output buffer and convert directly into an RGBA native window, removing the full-frame Java buffer copy. Normalize the alternate YUV output to Media3's planar 8-bit 4:2:0 contract, including 10-bit and 4:4:4 inputs.

Preserve the unknown-matrix tag and Media3's BT.709 fallback. Configure range before initializing swscale and rebuild the cache when frame configuration changes, so full-range planar input is converted correctly. Disconnect invalid locked buffers before unlocking to prevent unwritten frames from being posted. Keep every allocated output buffer and reclaim renderer-held frames after joining the decoder thread; late releases are safe. Reuse the existing native padding-size getter. The change also removes the packet allocation leak, zeroes input/extradata padding and retains valid JNI surface references.

Companion validation PR: https://github.com/anilbeesetti/nextplayer/pull/1904

## Current performance evidence

Fresh H.264 1080p60 comparison: baseline nextlib `40a9f16` versus review fix `06d62f0`, Next Player debug APK on the same disposable emulator. Five measured runs per revision after one excluded warm-up; 600 frames for uncapped decode and 300 for rendering.

| Metric | Baseline | Review fix | Change |
| --- | ---: | ---: | ---: |
| Uncapped decode | 879.19 fps | 1,027.26 fps | +16.8% |
| Decode CPU/frame | 2.880 ms | 2.730 ms | −5.2% |
| Decode + render CPU/frame | 6.257 ms | 6.377 ms | +1.9% |
| Surface throughput | 60.031 fps | 60.033 fps | Essentially unchanged |

Decode headroom remains improved. This repeat does not establish a rendering CPU saving. The report preserves the initial ten-run H.264 comparison (+21.5%) and HEVC/VP9 results, explicitly tied to the earlier `483ed3c` revision. HEVC/VP9 were not remeasured for the review changes. These emulator/debug numbers do not establish physical-device or battery gains; HDR tone mapping is outside this change.

## Verification

- Next Player with local nextlib: `./gradlew -PnextlibPath=/path/to/nextlib --init-script /path/to/enforce-tests.gradle assembleDebug :app:assembleDebugAndroidTest test ktlintCheck :nextlib:media3ext:test` — passed. The report includes the script that enforces test failures; 158 Next Player and 10 nextlib unique debug tests.
- `python3 ffmpeg/test_setup.py` — passed. Native builds cover all four ABIs.
- Disposable ARM64 Pixel 6a emulator, API 37 / Android 37.1, 16 KB pages, host GPU: ten review regression invocations pass, including five color-bar fixtures, unknown/BT.601 YUV metadata, full-to-limited YUV, held-output release and the actual Next Player decoder-switch/seek/pause/resume flow. The held-output and untagged BT.709 tests fail on the pre-review APK.
- Native checks against bundled FFmpeg verify matrix/range cache transitions, including full-range YUV420P. That range assertion fails with the pre-review scaler. Five injected invalid buffer cases use real Android buffers: zero images posted, and each same Surface renders successfully afterwards.
- The final surface-disconnect retry follow-up (`a884d8d`) passes the native checks and actual Next Player switching test again. Its packaged JNI matches the local build; all five FFmpeg libraries remain byte-identical to the baseline.
- Final APK installed and launched on the connected CPH2689 Android 16 phone for manual testing. Physical-device performance is not measured.

[Full report and reproduction commands](https://github.com/anilbeesetti/nextplayer/blob/331e333869e181fedc6a41b073fc7fd27dfe2568/feature/player/FFMPEG_PERFORMANCE.md) · [Before/after regression logs and repeat benchmark data](https://github.com/anilbeesetti/nextplayer/tree/331e333869e181fedc6a41b073fc7fd27dfe2568/feature/player/verification/ffmpeg/review)

## Initial rendering comparison (`483ed3c`)


| Next Player before | Next Player after |
| --- | --- |
| ![Incorrect colors](https://raw.githubusercontent.com/anilbeesetti/nextplayer/e4fe9155e0783098d0ba55b058f773d9ad9dfcd1/feature/player/verification/ffmpeg/before-playback.png) | ![Corrected colors](https://raw.githubusercontent.com/anilbeesetti/nextplayer/e4fe9155e0783098d0ba55b058f773d9ad9dfcd1/feature/player/verification/ffmpeg/after-playback.png) |

| SwiftShader before | SwiftShader after |
| --- | --- |
| ![Green output](https://raw.githubusercontent.com/anilbeesetti/nextplayer/e4fe9155e0783098d0ba55b058f773d9ad9dfcd1/feature/player/verification/ffmpeg/before-swiftshader-bars-420.png) | ![Corrected color bars](https://raw.githubusercontent.com/anilbeesetti/nextplayer/e4fe9155e0783098d0ba55b058f773d9ad9dfcd1/feature/player/verification/ffmpeg/after-swiftshader-bars-420.png) |
