### PR TITLE
Update FFmpeg to 9.0.1 and mbedTLS to 3.6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,6 @@ Media3's `SimpleDecoder` input/output contract.
 
 See [AV1 verification](media3ext/AV1_VERIFICATION.md) for the Next Player playback
 checks and tested device coverage.
+
+See [FFmpeg and mbedTLS upgrade verification](ffmpeg/UPGRADE_VERIFICATION.md) for
+the current dependency build, TLS, rotation metadata, and playback checks.

--- a/README.md
+++ b/README.md
@@ -69,9 +69,8 @@ application-owned error handling.
 
 Use macOS or Linux (WSL on Windows), JDK 17+, `make`, `curl`, `tar`, and
 `pkg-config`, Meson, Ninja, and NASM 2.14+ (`brew install meson ninja nasm` on
-macOS; `sudo apt-get install meson ninja-build nasm` on Ubuntu). On Apple Silicon,
-also install native `yasm` (`brew install yasm`)
-for the x86 ABIs; the pinned NDK bundles an Intel-only assembler. Install [Android CLI](https://developer.android.com/tools/agents/android-cli/download)
+macOS; `sudo apt-get install meson ninja-build nasm` on Ubuntu). NASM is used for
+both FFmpeg and dav1d's x86 assembly. Install [Android CLI](https://developer.android.com/tools/agents/android-cli/download)
 and put `android` on PATH, or set `ANDROID_CLI` to its executable path.
 Set `sdk.dir` in `local.properties` or export `ANDROID_HOME` to your Android SDK.
 
@@ -85,7 +84,9 @@ NDK and CMake versions come from `gradle/libs.versions.toml`. Existing SDK tools
 are reused; Android CLI is only needed when a package is missing. Complete any
 SDK license prompts during initial installation before running a headless build.
 
-The build pins dav1d 1.5.4 and statically links it into FFmpeg's `libavcodec.so`
+The build pins FFmpeg 9.0.1, mbedTLS 3.6.7 (the 3.6 LTS branch), and dav1d 1.5.4.
+mbedTLS is built from its complete release archive and linked statically for
+HTTPS/TLS support. The build statically links dav1d into FFmpeg's `libavcodec.so`
 for every ABI, with assembly optimizations and both 8-bit and high-bit-depth AV1
 support. AV1 uses the `libdav1d` decoder in Media3 and in media-info/thumbnail lookups.
 

--- a/ffmpeg/UPGRADE_VERIFICATION.md
+++ b/ffmpeg/UPGRADE_VERIFICATION.md
@@ -1,0 +1,103 @@
+# FFmpeg and mbedTLS upgrade verification — 2026-09-06
+
+NextLib implementation: `a22355c` on `codex/update-ffmpeg-mbedtls`.
+
+- [FFmpeg 9.0.1](https://ffmpeg.org/download.html) replaces 6.0.
+- [mbedTLS 3.6.7](https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.7)
+  replaces 3.4.1. It stays on the 3.6 LTS branch and requires no FFmpeg patch.
+- dav1d remains at 1.5.4.
+- The build uses the complete mbedTLS release archive, static PIC libraries,
+  NASM for FFmpeg x86 assembly, and Clang's `x86-64` CPU spelling.
+- Rotation metadata now comes from `AVCodecParameters::coded_side_data`,
+  replacing FFmpeg's removed `av_stream_get_side_data` API.
+
+## Library checks
+
+Passed with JDK 17, NDK 25.2.9519653, and CMake 3.22.1:
+
+```sh
+python3 ffmpeg/test_setup.py
+bash -n ffmpeg/setup.sh mediainfo/src/test/cpp/run_rotation_test.sh
+./gradlew assembleDebug assembleRelease test
+```
+
+Both modules built debug and release AARs for ARM64, ARMv7, x86, and x86_64.
+All 11 JVM tests passed. Every ABI's five FFmpeg shared libraries has at least
+16 KB ELF LOAD alignment. The binaries contain FFmpeg 9.0.1, mbedTLS 3.6.7,
+and dav1d 1.5.4, with no dynamic mbedTLS or dav1d dependency.
+
+## Emulator checks
+
+Disposable Pixel 6a profile, ARM64, Android 17 / API 37, Android 37.1 system
+image with 16 KB pages, 720×1600 display, SwiftShader rendering.
+
+```sh
+export ANDROID_NDK_HOME=/path/to/sdk/ndk/25.2.9519653
+export ANDROID_SERIAL=emulator-5584
+bash media3ext/src/test/cpp/run_av1_decoder_test.sh
+bash media3ext/src/test/cpp/run_ffvideo_test.sh
+bash mediainfo/src/test/cpp/run_rotation_test.sh
+```
+
+- AV1 8-bit and 10-bit film-grain clips each produced all 48 frames before
+  and after seek/flush, with no delayed frames at EOS.
+- VP9 packet retries, hidden alt-ref frames, pending-output reset, decoder
+  discovery, color conversion, and invalid surface buffer regressions passed.
+- Rotation tests passed for absent metadata, negative rotate tags, display
+  matrix precedence, 90°/180° matrices, and truncated matrix fallback.
+- An ARM64 `avio_open2`/`avio_read` smoke test fetched a known payload three
+  times from a local HTTPS server with certificate verification enabled and
+  a generated trusted CA. A fourth connection using an unrelated CA failed
+  as expected. This passed separately with the server restricted to TLS 1.2
+  and TLS 1.3. The probe also asserted `av_version_info()` equals `9.0.1`.
+
+Runtime coverage is ARM64 on this emulator; the other ABIs were built and
+their ELF files inspected.
+
+## Next Player integration
+
+Next Player `dbc2a15f` passed `assembleDebug test ktlintCheck` with
+`-PnextlibPath=/path/to/nextlib/.worktrees/ffmpeg-mbedtls-update` and a temporary
+Gradle init script (`-I /path/to/validation.gradle`):
+
+```groovy
+settingsEvaluated { settings ->
+    if (settings.rootDir.name == 'nextplayer') {
+        settings.dependencyResolutionManagement.versionCatalogs.maybeCreate('libs')
+            .version('androidGradlePlugin', '9.4.0')
+    }
+}
+gradle.projectsEvaluated {
+    gradle.rootProject.allprojects {
+        tasks.withType(Test).configureEach { ignoreFailures = false }
+    }
+}
+```
+
+The temporary override aligns Next Player's AGP 9.3.1 with NextLib's existing
+AGP 9.4.0 for composite-build validation; no Next Player source changes were made.
+All 167 Next Player tests passed with no failures, errors, or skips. The FFmpeg
+libraries in every ABI APK match this worktree's libraries byte-for-byte.
+
+On the disposable emulator:
+
+- The 40-second 10-bit AV1 clip rendered correctly after selecting **Video → SW**.
+  Logs confirmed `ffmpegLavc63.1.101-libdav1d` and a rendered first frame.
+- Selecting **Audio → SW** initialized `ffmpegLavc63.1.101-aac`; playback
+  advanced and paused normally. Audio output was checked through decoder and
+  playback state, not by listening to the headless emulator.
+- Seeking while paused reached 29,173 ms and displayed the corresponding frame.
+- H.264 playback initialized `ffmpegLavc63.1.101-h264` and rendered moving frames.
+- A native probe using the production thumbnail rotation reader opened a real
+  MP4 carrying a 90° counterclockwise display matrix and correctly returned
+  270° clockwise. Its metadata was independently checked with host `ffprobe`.
+- Playback screenshots were visually inspected. App logs contained no playback
+  or packet send/receive errors, and the final crash buffer was empty.
+
+### Observed playback limitations
+
+The existing FFmpeg surface renderer does not apply the rotated MP4's display
+matrix to playback. Its Java and C++ rendering code is unchanged by this upgrade;
+the API migration above covers media-info and thumbnail rotation metadata.
+Also, this emulator's Android software AV1 decoder displayed corrupted 10-bit
+output before switching to FFmpeg; FFmpeg's dav1d output rendered correctly.

--- a/ffmpeg/setup.sh
+++ b/ffmpeg/setup.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # Versions
 DAV1D_VERSION=1.5.4
-MBEDTLS_VERSION=3.4.1
-FFMPEG_VERSION=6.0
+MBEDTLS_VERSION=3.6.7
+FFMPEG_VERSION=9.0.1
 
 # Directories
 BASE_DIR=$(cd "$(dirname "$0")" && pwd)
@@ -58,8 +58,6 @@ for tool in curl tar make pkg-config meson ninja nasm; do
   command -v "$tool" >/dev/null || { echo "Missing build tool: $tool" >&2; exit 1; }
 done
 
-X86_AS=$(command -v yasm || printf '%s\n' "${TOOLCHAIN_PREFIX}/bin/yasm")
-
 mkdir -p "$SOURCES_DIR"
 
 # Publish a source directory only after a complete download and extraction.
@@ -67,8 +65,8 @@ downloadSource() (
   destination=$2
   staging=$(mktemp -d "$SOURCES_DIR/.download.XXXXXX")
   trap 'rm -rf "$staging"' EXIT
-  curl --fail --location --retry 3 "$1" -o "$staging/source.tar.gz"
-  tar -zxf "$staging/source.tar.gz" -C "$staging"
+  curl --fail --location --retry 3 "$1" -o "$staging/source.tar"
+  tar -xf "$staging/source.tar" -C "$staging"
   mv "$staging/$(basename "$destination")" "$destination"
 )
 
@@ -127,7 +125,13 @@ function buildMbedTLS() {
        -DANDROID_ABI=$ABI \
        -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" \
        -DCMAKE_INSTALL_PREFIX="$BUILD_DIR/external/$ABI" \
+       -DCMAKE_INSTALL_LIBDIR=lib \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
        -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384" \
+       -DUSE_STATIC_MBEDTLS_LIBRARY=ON \
+       -DUSE_SHARED_MBEDTLS_LIBRARY=OFF \
+       -DENABLE_PROGRAMS=OFF \
        -DENABLE_TESTING=0
 
       make -j$JOBS
@@ -171,7 +175,7 @@ function buildFfmpeg() {
       ;;
     x86_64)
       TOOLCHAIN=x86_64-linux-android21-
-      CPU=x86_64
+      CPU=x86-64
       ARCH=x86_64
       ;;
     *)
@@ -188,7 +192,7 @@ function buildFfmpeg() {
     PKG_CONFIG_PATH= PKG_CONFIG_LIBDIR="$BUILD_DIR/external/$ABI/lib/pkgconfig" ./configure \
       --prefix="$BUILD_DIR/$ABI" \
       --enable-cross-compile \
-      --x86asmexe="$X86_AS" \
+      --x86asmexe="$(command -v nasm)" \
       --arch=$ARCH \
       --cpu=$CPU \
       --cross-prefix="${TOOLCHAIN_PREFIX}/bin/$TOOLCHAIN" \
@@ -209,7 +213,6 @@ function buildFfmpeg() {
       --disable-vulkan \
       --disable-avdevice \
       --disable-avformat \
-      --disable-postproc \
       --disable-avfilter \
       --disable-symver \
       --enable-parsers \
@@ -245,7 +248,8 @@ function buildFfmpeg() {
 
 # Gradle owns up-to-date checks. Existing directories can be left by failed builds.
 if [[ ! -d "$MBEDTLS_DIR" ]]; then
-  downloadSource "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v${MBEDTLS_VERSION}.tar.gz" "$MBEDTLS_DIR"
+  # GitHub's generated source archives omit required submodules/generated files.
+  downloadSource "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-${MBEDTLS_VERSION}/mbedtls-${MBEDTLS_VERSION}.tar.bz2" "$MBEDTLS_DIR"
 fi
 if [[ ! -d "$FFMPEG_DIR" ]]; then
   downloadSource "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz" "$FFMPEG_DIR"
@@ -253,6 +257,7 @@ fi
 if [[ ! -d "$DAV1D_DIR" ]]; then
   downloadSource "https://github.com/videolan/dav1d/archive/refs/tags/${DAV1D_VERSION}.tar.gz" "$DAV1D_DIR"
 fi
+
 buildMbedTLS
 buildDav1d
 buildFfmpeg

--- a/ffmpeg/test_setup.py
+++ b/ffmpeg/test_setup.py
@@ -18,7 +18,7 @@ with tempfile.TemporaryDirectory(prefix='nextlib setup ') as temp:
     ffmpeg = root / 'ffmpeg'
     ffmpeg.mkdir()
     shutil.copy(Path(__file__).with_name('setup.sh'), ffmpeg)
-    for name in ('mbedtls-3.4.1', 'ffmpeg-6.0', 'dav1d-1.5.4'):
+    for name in ('mbedtls-3.6.7', 'ffmpeg-9.0.1', 'dav1d-1.5.4'):
         (ffmpeg / 'sources' / name).mkdir(parents=True)
     # Partial previous builds must not suppress a retry.
     (ffmpeg / 'build').mkdir()
@@ -57,22 +57,23 @@ with tempfile.TemporaryDirectory(prefix='nextlib setup ') as temp:
     result = run()
     assert result.returncode == 42 and 'native-build-reached' in result.stderr, result
     assert not log.exists()
-    source = ffmpeg / 'sources/mbedtls-3.4.1'
+    source = ffmpeg / 'sources/mbedtls-3.6.7'
     shutil.rmtree(source)
     executable(root / 'bin/curl', 'exit 22\n')
     result = run()
     assert result.returncode == 22 and not source.exists()
     assert not list((ffmpeg / 'sources').glob('.download.*'))
-    archive = root / 'source.tar.gz'
-    with tarfile.open(archive, 'w:gz') as tar:
-        directory = tarfile.TarInfo('mbedtls-3.4.1')
+    archive = root / 'source.tar.bz2'
+    with tarfile.open(archive, 'w:bz2') as tar:
+        directory = tarfile.TarInfo('mbedtls-3.6.7')
         directory.type = tarfile.DIRTYPE
         directory.mode = 0o755
         tar.addfile(directory)
     env['SOURCE_ARCHIVE'] = str(archive)
-    executable(root / 'bin/curl', 'cp "$SOURCE_ARCHIVE" "${@: -1}"\n')
+    executable(root / 'bin/curl', 'printf "%s\\n" "$@" > "$CLI_LOG"\ncp "$SOURCE_ARCHIVE" "${@: -1}"\n')
     result = run()
     assert result.returncode == 42 and source.is_dir(), result
+    assert 'https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.7/mbedtls-3.6.7.tar.bz2' in log.read_text().splitlines()
     assert not list((ffmpeg / 'sources').glob('.download.*'))
 
     # Exercise dav1d's cross-build and FFmpeg's target-only dependency discovery.
@@ -81,7 +82,7 @@ with tempfile.TemporaryDirectory(prefix='nextlib setup ') as temp:
     executable(root / 'bin/meson', '''
 printf '%s\\n' "$@" > "$2.args"
 ''')
-    executable(ffmpeg / 'sources/ffmpeg-6.0/configure', '''
+    executable(ffmpeg / 'sources/ffmpeg-9.0.1/configure', '''
 prefix=${1#--prefix=}
 mkdir -p "$prefix/lib" "$prefix/include"
 touch "$prefix/lib/libavcodec.so" "$prefix/include/avcodec.h"
@@ -109,6 +110,10 @@ printf '%s\\n' "$PKG_CONFIG_PATH" "$PKG_CONFIG_LIBDIR" > "$prefix/pkgconfig.env"
                        '--enable-decoder=vp9', '--pkg-config-flags=--static'):
             assert option in args, (abi, option)
         assert '--enable-libvpx' not in args
+        assert f'--x86asmexe={root / "bin/nasm"}' in args
+        assert '--disable-postproc' not in args
+        if abi == 'x86_64':
+            assert '--cpu=x86-64' in args
         assert (ffmpeg / f'build/{abi}/pkgconfig.env').read_text().splitlines() == [
             '', str(ffmpeg / f'build/external/{abi}/lib/pkgconfig')]
     executable(root / 'bin/ninja', 'exit 43\n')

--- a/mediainfo/src/main/cpp/media_thumbnail_retriever.cpp
+++ b/mediainfo/src/main/cpp/media_thumbnail_retriever.cpp
@@ -44,9 +44,11 @@ static int read_rotation_degrees(AVStream *stream) {
         rotation = normalize_rotation(atoi(rotateTag->value));
     }
 
-    uint8_t *displayMatrix = av_stream_get_side_data(stream, AV_PKT_DATA_DISPLAYMATRIX, nullptr);
-    if (displayMatrix) {
-        double theta = av_display_rotation_get(reinterpret_cast<int32_t *>(displayMatrix));
+    const AVPacketSideData *displayMatrix = av_packet_side_data_get(
+            stream->codecpar->coded_side_data, stream->codecpar->nb_coded_side_data,
+            AV_PKT_DATA_DISPLAYMATRIX);
+    if (displayMatrix && displayMatrix->size >= 9 * sizeof(int32_t)) {
+        double theta = av_display_rotation_get(reinterpret_cast<const int32_t *>(displayMatrix->data));
         rotation = normalize_rotation(static_cast<int>(-theta));
     }
 

--- a/mediainfo/src/main/cpp/mediainfo.cpp
+++ b/mediainfo/src/main/cpp/mediainfo.cpp
@@ -86,11 +86,11 @@ void onVideoStreamFound(JNIEnv *env, jobject jMediaInfoBuilder, AVFormatContext 
         rotation %= 360;
         if (rotation < 0) rotation += 360;
     }
-    uint8_t *displaymatrix = av_stream_get_side_data(stream,
-                                                     AV_PKT_DATA_DISPLAYMATRIX,
-                                                     nullptr);
-    if (displaymatrix) {
-        double theta = av_display_rotation_get((int32_t *) displaymatrix);
+    const AVPacketSideData *displayMatrix = av_packet_side_data_get(
+            parameters->coded_side_data, parameters->nb_coded_side_data,
+            AV_PKT_DATA_DISPLAYMATRIX);
+    if (displayMatrix && displayMatrix->size >= 9 * sizeof(int32_t)) {
+        double theta = av_display_rotation_get(reinterpret_cast<const int32_t *>(displayMatrix->data));
         rotation = (int) (-theta) % 360;
         if (rotation < 0) rotation += 360;
     }

--- a/mediainfo/src/test/cpp/rotation_test.cpp
+++ b/mediainfo/src/test/cpp/rotation_test.cpp
@@ -1,0 +1,34 @@
+#include <cassert>
+#include <cstdio>
+
+#include "../../main/cpp/media_thumbnail_retriever.cpp"
+
+int main() {
+    AVFormatContext *format = avformat_alloc_context();
+    assert(format);
+    AVStream *stream = avformat_new_stream(format, nullptr);
+    assert(stream);
+    assert(read_rotation_degrees(nullptr) == 0);
+    assert(read_rotation_degrees(stream) == 0);
+
+    av_dict_set(&stream->metadata, "rotate", "-90", 0);
+    assert(read_rotation_degrees(stream) == 270);
+
+    AVPacketSideData *matrix = av_packet_side_data_new(
+            &stream->codecpar->coded_side_data, &stream->codecpar->nb_coded_side_data,
+            AV_PKT_DATA_DISPLAYMATRIX, 9 * sizeof(int32_t), 0);
+    assert(matrix);
+    av_display_rotation_set(reinterpret_cast<int32_t *>(matrix->data), 90);
+    assert(read_rotation_degrees(stream) == 90);
+    av_display_rotation_set(reinterpret_cast<int32_t *>(matrix->data), 180);
+    assert(read_rotation_degrees(stream) == 180);
+
+    // Truncated side data must not be read as a 3x3 display matrix.
+    matrix->size = sizeof(int32_t);
+    assert(read_rotation_degrees(stream) == 270);
+    av_dict_set(&stream->metadata, "rotate", nullptr, 0);
+    assert(read_rotation_degrees(stream) == 0);
+
+    avformat_free_context(format);
+    puts("Rotation metadata checks passed");
+}

--- a/mediainfo/src/test/cpp/run_rotation_test.sh
+++ b/mediainfo/src/test/cpp/run_rotation_test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Requires a disposable ARM64 Android emulator.
+set -euo pipefail
+: "${ANDROID_NDK_HOME:?Set ANDROID_NDK_HOME}"
+: "${ANDROID_SERIAL:?Set ANDROID_SERIAL to a disposable ARM64 emulator}"
+repo=$(cd "$(dirname "$0")/../../../.." && pwd)
+build=$(mktemp -d)
+trap 'rm -rf "$build"' EXIT
+compiler="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++"
+if [[ ! -x "$compiler" ]]; then
+    compiler="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++"
+fi
+"$compiler" --target=aarch64-linux-android23 -std=c++17 -O2 -static-libstdc++ \
+    -Wl,-z,max-page-size=16384 -I"$repo/ffmpeg/output/include/arm64-v8a" \
+    "$repo/mediainfo/src/test/cpp/rotation_test.cpp" \
+    -L"$repo/ffmpeg/output/lib/arm64-v8a" -lavformat -lavcodec -lavutil -lswscale \
+    -ljnigraphics -o "$build/rotation_test"
+device_dir=/data/local/tmp/nextlib-rotation-test
+adb shell mkdir -p "$device_dir"
+adb push "$build/rotation_test" "$repo"/ffmpeg/output/lib/arm64-v8a/*.so "$device_dir/" >/dev/null
+adb shell "cd $device_dir && LD_LIBRARY_PATH=. ./rotation_test"


### PR DESCRIPTION
Updates FFmpeg from 6.0 to 9.0.1 and mbedTLS from 3.4.1 to 3.6.7. mbedTLS stays on the 3.6 LTS series, so FFmpeg needs no compatibility patch.

The build now uses the complete mbedTLS release archive and static PIC libraries, NASM for FFmpeg x86 assembly, and the supported `x86-64` CPU spelling. It also removes the obsolete postproc configure option. Media-info and thumbnail rotation readers use `AVCodecParameters::coded_side_data` after removal of `av_stream_get_side_data`, with regression coverage for rotation and truncated metadata.

## Verification

- `python3 ffmpeg/test_setup.py` and shell syntax checks passed.
- `./gradlew assembleDebug assembleRelease test` passed: both modules, all four ABIs, and 11 JVM tests.
- All FFmpeg shared libraries have at least 16 KB ELF LOAD alignment; mbedTLS and dav1d are statically linked.
- Native AV1, VP9, and rotation tests passed on a disposable ARM64 Pixel 6a emulator running Android 17 / API 37 with 16 KB pages.
- HTTPS reads with certificate verification passed separately over TLS 1.2 and TLS 1.3; an untrusted CA was rejected.
- Next Player integration passed `assembleDebug test ktlintCheck`, including 167 tests. Emulator checks covered FFmpeg AV1/H.264 playback, AAC decoder initialization, seeking, and rotation metadata.

See [upgrade verification notes](https://github.com/anilbeesetti/nextlib/blob/codex/update-ffmpeg-mbedtls/ffmpeg/UPGRADE_VERIFICATION.md) for commands, environment details, and the temporary AGP alignment used for Next Player's composite build. Runtime coverage is ARM64; the remaining ABIs were built and inspected.

## Known limitation

The existing FFmpeg surface renderer does not apply display-matrix rotation during playback. Its rendering code is unchanged; this upgrade preserves rotation metadata handling in media-info and thumbnails.
