### PR TITLE
docs: enable FFmpeg renderers in basic usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,28 @@ dependencies {
 
 ## Basic usage
 
-Use `NextRenderersFactory` as a drop-in `DefaultRenderersFactory` replacement to make the bundled
-FFmpeg decoders available to Media3:
+Use `NextRenderersFactory` with extension renderers enabled to make the bundled FFmpeg decoders
+available to Media3. The factory retains `DefaultRenderersFactory`'s default of `OFF`:
 
 ```kotlin
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.ExoPlayer
+import io.github.anilbeesetti.nextlib.media3ext.ffdecoder.NextRenderersFactory
+
+// OFF: Do not add FFmpeg extension renderers.
+// ON: Enable them at normal priority, after platform renderers.
+// PREFER: Give FFmpeg extension renderers priority.
 val renderersFactory = NextRenderersFactory(applicationContext)
+    .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
 
 ExoPlayer.Builder(applicationContext)
     .setRenderersFactory(renderersFactory)
     .build()
 ```
+
+This controls renderer priority and capability fallback: `ON` allows FFmpeg when platform
+renderers cannot support a format. It does not automatically recover from runtime decoder failures;
+applications own error recovery.
 
 ## Runtime decoder switching
 
@@ -61,7 +73,8 @@ decoderManager.detach()
 player.release()
 ```
 
-Video and audio are selected independently. See
+Installing a `DecoderManager` enables extension renderers at normal priority (`ON`) and MediaCodec
+initialization fallback. Video and audio are selected independently. See
 [`media3ext/DECODER_SWITCHING.md`](media3ext/DECODER_SWITCHING.md) for mode behavior, lifecycle, and
 application-owned error handling.
 


### PR DESCRIPTION
The basic usage example inherited Media3's `OFF` default, so copying it did not add the bundled FFmpeg renderers. Explicitly enable `EXTENSION_RENDERER_MODE_ON`, include the imports, and explain OFF/ON/PREFER priority and capability fallback. Clarify that applications handle runtime decoder failures and that installing a `DecoderManager` already enables ON and MediaCodec initialization fallback.

Only README.md changes; factory defaults and implementation are unchanged.

Validation passed:
- NextLib debug builds for all four ABIs, 11 JVM tests, Android lint (0 errors), FFmpeg setup regression, and all 8 native video regression checks.
- Isolated Next Player composite build against this worktree: all ABI APKs, 205 JVM tests with failures enforced, and ktlint. Only the disposable player's AGP version was aligned from 9.3.1 to 9.4.0 for the composite build.
- Android 16/API 36 ARM64 emulator playback and seeking using the basic factory construction without a DecoderManager: ON selected platform H.264/AAC and FFmpeg MPEG-2/AC-3 fallback; PREFER selected FFmpeg H.264/AAC; OFF omitted both FFmpeg renderers and played with platform decoders.

The final four playback runs had no player errors and empty crash buffers. These were functional emulator checks, not physical-device performance or runtime-error-recovery tests. Generated evidence and temporary integration probes are excluded from the change; the task-owned emulator was removed.
