### PR TITLE
Fix: TrueHD output format access during reset

### DIFF
--- a/media3ext/src/main/cpp/ffaudio.cpp
+++ b/media3ext/src/main/cpp/ffaudio.cpp
@@ -313,14 +313,14 @@ Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegAudioDecoder_ffmpe
     if (codecId == AV_CODEC_ID_TRUEHD) {
         // Release and recreate the context if the codec is TrueHD.
         // TODO: Figure out why flushing doesn't work for this codec.
+        auto outputFloat =
+                (jboolean) (context->request_sample_fmt == OUTPUT_FORMAT_PCM_FLOAT);
         releaseContext(context);
         auto *codec = const_cast<AVCodec *>(avcodec_find_decoder(codecId));
         if (!codec) {
             LOGE("Unexpected error finding codec %d.", codecId);
             return 0L;
         }
-        auto outputFloat =
-                (jboolean) (context->request_sample_fmt == OUTPUT_FORMAT_PCM_FLOAT);
         return (jlong) createContext(env, codec, extra_data, outputFloat,
                 /* rawSampleRate= */ -1,
                 /* rawChannelCount= */ -1);

--- a/media3ext/src/test/cpp/ffaudio_reset_test.cpp
+++ b/media3ext/src/test/cpp/ffaudio_reset_test.cpp
@@ -1,0 +1,69 @@
+// Exercise the production TrueHD reset and shared context release with real decoding.
+#include "../../main/cpp/ffaudio.cpp"
+extern "C" {
+#include <libavformat/avformat.h>
+}
+#include <cassert>
+#include <cstdio>
+#include <vector>
+
+int main(int argc, char **argv) {
+    assert(argc == 2);
+    AVFormatContext *input = nullptr;
+    assert(avformat_open_input(&input, argv[1], nullptr, nullptr) == 0);
+    assert(avformat_find_stream_info(input, nullptr) >= 0);
+    const int stream = av_find_best_stream(input, AVMEDIA_TYPE_AUDIO, -1, -1, nullptr, 0);
+    assert(stream >= 0 && input->streams[stream]->codecpar->codec_id == AV_CODEC_ID_TRUEHD);
+    std::vector<AVPacket *> packets;
+    AVPacket *packet = av_packet_alloc();
+    assert(packet);
+    int result;
+    while ((result = av_read_frame(input, packet)) >= 0) {
+        if (packet->stream_index == stream) {
+            packets.push_back(av_packet_clone(packet));
+            assert(packets.back());
+        }
+        av_packet_unref(packet);
+    }
+    assert(result == AVERROR_EOF && !packets.empty());
+    av_packet_free(&packet);
+    avformat_close_input(&input);
+
+    auto *codec = const_cast<AVCodec *>(avcodec_find_decoder(AV_CODEC_ID_TRUEHD));
+    assert(codec);
+    size_t pcm16Bytes = 0;
+    for (bool outputFloat : {false, true}) {
+        AVCodecContext *context = createContext(nullptr, codec, nullptr, outputFloat, -1, -1);
+        assert(context);
+        std::vector<uint8_t> expected;
+        for (int pass = 0; pass <= 32; ++pass) {
+            assert(context->request_sample_fmt == (outputFloat ? AV_SAMPLE_FMT_FLT : AV_SAMPLE_FMT_S16));
+            assert(context->opaque == nullptr);
+            std::vector<uint8_t> decoded;
+            uint8_t output[131072];
+            for (AVPacket *sample : packets) {
+                const int size = decodePacket(context, sample, output, sizeof(output), {});
+                assert(size >= 0);
+                decoded.insert(decoded.end(), output, output + size);
+            }
+            assert(!decoded.empty() && context->opaque);
+            assert(context->sample_rate == 48000 && context->ch_layout.nb_channels == 2);
+            if (pass == 0) expected = decoded;
+            else assert(decoded == expected);
+            if (pass == 32) break;
+            context = reinterpret_cast<AVCodecContext *>(
+                    Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegAudioDecoder_ffmpegReset(
+                            nullptr, nullptr, reinterpret_cast<jlong>(context), nullptr));
+            assert(context);
+        }
+        if (outputFloat) assert(expected.size() == pcm16Bytes * 2);
+        else pcm16Bytes = expected.size();
+        Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegAudioDecoder_ffmpegRelease(
+                nullptr, nullptr, reinterpret_cast<jlong>(context));
+        printf("PASS: TrueHD %s, 32 resets, identical PCM (%zu bytes per decode)\n",
+               outputFloat ? "float" : "16-bit", expected.size());
+    }
+    for (AVPacket *sample : packets) av_packet_free(&sample);
+    assert(Java_io_github_anilbeesetti_nextlib_media3ext_ffdecoder_FfmpegAudioDecoder_ffmpegReset(
+            nullptr, nullptr, 0, nullptr) == 0);
+}

--- a/media3ext/src/test/cpp/run_ffaudio_reset_test.sh
+++ b/media3ext/src/test/cpp/run_ffaudio_reset_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Requires built FFmpeg libraries, host ffmpeg, and a disposable ARM64 API 26+ emulator.
+set -euo pipefail
+: "${ANDROID_NDK_HOME:?Set ANDROID_NDK_HOME}"
+: "${ANDROID_SERIAL:?Set ANDROID_SERIAL to a disposable ARM64 emulator}"
+repo=$(cd "$(dirname "$0")/../../../.." && pwd)
+build=$(mktemp -d)
+device_dir=/data/local/tmp/nextlib-ffaudio-$(basename "$build")
+trap 'adb -s "$ANDROID_SERIAL" shell rm -rf "$device_dir" >/dev/null; rm -rf "$build"' EXIT
+compiler="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++"
+if [[ ! -x "$compiler" ]]; then
+    compiler="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++"
+fi
+asan=$("$compiler" --target=aarch64-linux-android26 -print-file-name=libclang_rt.asan-aarch64-android.so)
+"$compiler" --target=aarch64-linux-android26 -std=c++17 -O1 -g \
+    -fsanitize=address -fno-omit-frame-pointer -static-libstdc++ \
+    -Wl,-z,max-page-size=16384 -I"$repo/ffmpeg/output/include/arm64-v8a" \
+    "$repo/media3ext/src/test/cpp/ffaudio_reset_test.cpp" "$repo/media3ext/src/main/cpp/ffcommon.cpp" \
+    -L"$repo/ffmpeg/output/lib/arm64-v8a" -lavformat -lavcodec -lavutil -lswresample \
+    -landroid -llog -o "$build/ffaudio_reset_test"
+ffmpeg -hide_banner -loglevel error -f lavfi -i 'sine=frequency=997:sample_rate=48000' \
+    -t 0.1 -ac 2 -c:a truehd -strict experimental "$build/truehd.mka"
+adb -s "$ANDROID_SERIAL" shell mkdir -p "$device_dir"
+adb -s "$ANDROID_SERIAL" push "$build/ffaudio_reset_test" "$build/truehd.mka" "$asan" \
+    "$repo"/ffmpeg/output/lib/arm64-v8a/*.so "$device_dir/" >/dev/null
+adb -s "$ANDROID_SERIAL" shell "cd $device_dir && LD_LIBRARY_PATH=. \
+    LD_PRELOAD=./libclang_rt.asan-aarch64-android.so ASAN_OPTIONS=detect_leaks=0 \
+    ./ffaudio_reset_test truehd.mka"


### PR DESCRIPTION
Resetting the TrueHD decoder after a seek read its output-format setting after the codec context had been freed. Capture that setting before releasing the context so reset safely preserves float or 16-bit PCM output.

Add a native regression using the production decode/reset code: decode TrueHD, reset 32 times for each output format, and verify identical PCM, sample rate, channel count, and fresh resampler state.