### PR TITLE
Fix FFmpeg video renderer capabilities and output cleanup

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ mavenPublish = "0.37.0"
 
 [libraries]
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidxAnnotation" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version = "1.7.0" }
 kotlin-annotations-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-annotations-jvm", version.ref = "kotlin" }
 androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "androidxMedia3" }
 checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerQual" }

--- a/media3ext/build.gradle.kts
+++ b/media3ext/build.gradle.kts
@@ -13,6 +13,7 @@ android {
     defaultConfig {
 
         minSdk = 23
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
         externalNativeBuild {
             cmake {
@@ -44,6 +45,12 @@ android {
     }
 }
 
+androidComponents {
+    onVariants { variant ->
+        variant.androidTest?.sources?.assets?.addStaticSourceDirectory("src/test/cpp/fixtures")
+    }
+}
+
 tasks.configureEach {
     if (name == "preBuild" || name.startsWith("configureCMake") || name.startsWith("buildCMake")) {
         dependsOn(":ffmpegSetup")
@@ -57,4 +64,6 @@ dependencies {
     compileOnly(libs.checker.qual)
     compileOnly(libs.kotlin.annotations.jvm)
     testImplementation(libs.junit)
+    androidTestImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.test.runner)
 }

--- a/media3ext/src/androidTest/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/FfmpegVideoRendererTest.java
+++ b/media3ext/src/androidTest/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/FfmpegVideoRendererTest.java
@@ -1,0 +1,185 @@
+package io.github.anilbeesetti.nextlib.media3ext.ffdecoder;
+
+import static org.junit.Assert.*;
+
+import android.graphics.PixelFormat;
+import android.media.Image;
+import android.media.ImageReader;
+import android.os.SystemClock;
+import android.view.Surface;
+import androidx.media3.common.C;
+import androidx.media3.common.DrmInitData;
+import androidx.media3.common.Format;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.decoder.DecoderInputBuffer;
+import androidx.media3.decoder.VideoDecoderOutputBuffer;
+import androidx.media3.exoplayer.DecoderReuseEvaluation;
+import androidx.media3.exoplayer.RendererCapabilities;
+import androidx.media3.exoplayer.video.DecoderVideoRenderer;
+import androidx.test.platform.app.InstrumentationRegistry;
+import java.io.DataInputStream;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+@UnstableApi
+public class FfmpegVideoRendererTest {
+    private static final Format VP9 = new Format.Builder()
+            .setSampleMimeType(MimeTypes.VIDEO_VP9).setWidth(64).setHeight(48).build();
+
+    private static FfmpegVideoRenderer renderer() {
+        return new FfmpegVideoRenderer(0, null, null, 0, 1, 1, 1);
+    }
+
+    @Test
+    public void capabilitiesRejectMissingUnsupportedAndEncryptedFormats() {
+        assertTrue("Tests require the bundled native decoder", FfmpegLibrary.isAvailable());
+        FfmpegVideoRenderer renderer = renderer();
+        assertSupport(renderer, new Format.Builder().build(), C.FORMAT_UNSUPPORTED_TYPE);
+        assertSupport(renderer, new Format.Builder().setSampleMimeType(MimeTypes.AUDIO_AAC).build(),
+                C.FORMAT_UNSUPPORTED_TYPE);
+        assertSupport(renderer, new Format.Builder().setSampleMimeType("video/unsupported").build(),
+                C.FORMAT_UNSUPPORTED_SUBTYPE);
+        assertSupport(renderer, VP9, C.FORMAT_HANDLED);
+        for (int cryptoType : new int[] {C.CRYPTO_TYPE_UNSUPPORTED, C.CRYPTO_TYPE_FRAMEWORK,
+                C.CRYPTO_TYPE_CUSTOM_BASE}) {
+            Format encrypted = VP9.buildUpon().setCryptoType(cryptoType).build();
+            assertNull(encrypted.drmInitData);
+            assertSupport(renderer, encrypted, C.FORMAT_UNSUPPORTED_DRM);
+        }
+        Format drm = VP9.buildUpon().setDrmInitData(new DrmInitData(
+                new DrmInitData.SchemeData(C.WIDEVINE_UUID, "video/mp4", new byte[] {1}))).build();
+        assertEquals(C.CRYPTO_TYPE_UNSUPPORTED, drm.cryptoType);
+        assertSupport(renderer, drm, C.FORMAT_UNSUPPORTED_DRM);
+    }
+
+    @Test
+    public void adaptationIsNotSeamlessAndKeepsInheritedNoReuse() throws Exception {
+        FfmpegVideoRenderer renderer = renderer();
+        int capabilities = renderer.supportsFormat(VP9);
+        assertEquals(RendererCapabilities.ADAPTIVE_NOT_SEAMLESS,
+                RendererCapabilities.getAdaptiveSupport(capabilities));
+        assertEquals(RendererCapabilities.TUNNELING_NOT_SUPPORTED,
+                RendererCapabilities.getTunnelingSupport(capabilities));
+        Method reuse = DecoderVideoRenderer.class.getDeclaredMethod(
+                "canReuseDecoder", String.class, Format.class, Format.class);
+        reuse.setAccessible(true);
+        for (Format next : new Format[] {VP9, VP9.buildUpon().setWidth(128).setHeight(96).build(),
+                VP9.buildUpon().setSampleMimeType(MimeTypes.VIDEO_H264).build()}) {
+            DecoderReuseEvaluation result = (DecoderReuseEvaluation) reuse.invoke(
+                    renderer, "ffmpeg-vp9", VP9, next);
+            assertEquals(DecoderReuseEvaluation.REUSE_RESULT_NO, result.result);
+        }
+        for (Method declared : FfmpegVideoRenderer.class.getDeclaredMethods()) {
+            assertNotEquals("canReuseDecoder", declared.getName());
+        }
+    }
+
+    @Test
+    public void missingDecoderStillReleasesOutputExactlyOnce() {
+        AtomicInteger releases = new AtomicInteger();
+        VideoDecoderOutputBuffer output = new VideoDecoderOutputBuffer(b -> releases.incrementAndGet());
+        FfmpegDecoderException error = assertThrows(FfmpegDecoderException.class,
+                () -> renderer().renderOutputBufferToSurface(output, null));
+        assertTrue(error.getMessage().contains("decoder is not initialized"));
+        assertEquals(1, releases.get());
+    }
+
+    @Test
+    public void renderFailureReturnsSingleBufferAndCleanupDoesNotFreeFrameAgain() throws Exception {
+        FfmpegVideoRenderer renderer = renderer();
+        FfmpegVideoDecoder decoder = (FfmpegVideoDecoder) renderer.createDecoder(VP9, null);
+        decoder.setOutputMode(C.VIDEO_OUTPUT_MODE_SURFACE_YUV);
+        VideoDecoderOutputBuffer output = null;
+        try {
+            for (int i = 0; i < 12; i++) {
+                output = decodeKeyFrame(decoder);
+                assertNotEquals(0, output.decoderPrivate);
+                output.mode = C.VIDEO_OUTPUT_MODE_YUV;
+                VideoDecoderOutputBuffer failed = output;
+                assertThrows(FfmpegDecoderException.class,
+                        () -> renderer.renderOutputBufferToSurface(failed, null));
+                assertEquals(0, output.decoderPrivate);
+            }
+        } finally {
+            decoder.release();
+        }
+        assertNotNull(output);
+        assertEquals(0, output.decoderPrivate);
+    }
+
+    @Test
+    public void nativeSurfaceFailureReleasesFrame() throws Exception {
+        FfmpegVideoRenderer renderer = renderer();
+        FfmpegVideoDecoder decoder = (FfmpegVideoDecoder) renderer.createDecoder(VP9, null);
+        decoder.setOutputMode(C.VIDEO_OUTPUT_MODE_SURFACE_YUV);
+        try (ImageReader images = ImageReader.newInstance(64, 48, PixelFormat.RGBA_8888, 2)) {
+            Surface invalid = images.getSurface();
+            invalid.release();
+            VideoDecoderOutputBuffer output = decodeKeyFrame(decoder);
+            assertNotEquals(0, output.decoderPrivate);
+            assertThrows(FfmpegDecoderException.class,
+                    () -> renderer.renderOutputBufferToSurface(output, invalid));
+            assertEquals(0, output.decoderPrivate);
+        } finally {
+            decoder.release();
+        }
+    }
+
+    @Test
+    public void successfulRenderAndDecoderFirstCleanupReleaseFrames() throws Exception {
+        FfmpegVideoRenderer renderer = renderer();
+        FfmpegVideoDecoder decoder = (FfmpegVideoDecoder) renderer.createDecoder(VP9, null);
+        decoder.setOutputMode(C.VIDEO_OUTPUT_MODE_SURFACE_YUV);
+        try (ImageReader images = ImageReader.newInstance(64, 48, PixelFormat.RGBA_8888, 2)) {
+            try {
+                VideoDecoderOutputBuffer rendered = decodeKeyFrame(decoder);
+                renderer.renderOutputBufferToSurface(rendered, images.getSurface());
+                assertEquals(0, rendered.decoderPrivate);
+                try (Image image = images.acquireNextImage()) {
+                    assertNotNull("Rendering must publish an image", image);
+                }
+                VideoDecoderOutputBuffer held = decodeKeyFrame(decoder);
+                assertNotEquals(0, held.decoderPrivate);
+                decoder.release();
+                assertEquals(0, held.decoderPrivate);
+                held.release();
+                assertEquals(0, held.decoderPrivate);
+            } finally {
+                decoder.release();
+            }
+        }
+    }
+
+    private static void assertSupport(FfmpegVideoRenderer renderer, Format format, int expected) {
+        assertEquals(expected, RendererCapabilities.getFormatSupport(renderer.supportsFormat(format)));
+    }
+
+    private static VideoDecoderOutputBuffer decodeKeyFrame(FfmpegVideoDecoder decoder) throws Exception {
+        byte[] packet;
+        try (DataInputStream asset = new DataInputStream(InstrumentationRegistry.getInstrumentation()
+                .getContext().getAssets().open("vp9.ivf"))) {
+            asset.skipBytes(32);
+            int size = Integer.reverseBytes(asset.readInt());
+            asset.skipBytes(8);
+            packet = new byte[size];
+            asset.readFully(packet);
+        }
+        DecoderInputBuffer input = decoder.dequeueInputBuffer();
+        assertNotNull(input);
+        input.ensureSpaceForWrite(packet.length);
+        input.data.put(packet);
+        input.timeUs = 0;
+        input.format = VP9;
+        input.flip();
+        decoder.queueInputBuffer(input);
+        long deadline = SystemClock.elapsedRealtime() + 5000;
+        VideoDecoderOutputBuffer output;
+        while ((output = decoder.dequeueOutputBuffer()) == null && SystemClock.elapsedRealtime() < deadline) {
+            SystemClock.sleep(5);
+        }
+        assertNotNull("Output pool starved or decoder failed to produce a frame", output);
+        return output;
+    }
+}

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/FfmpegVideoRenderer.java
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/FfmpegVideoRenderer.java
@@ -8,7 +8,6 @@ import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
-import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.TraceUtil;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
@@ -107,17 +106,17 @@ public final class FfmpegVideoRenderer extends DecoderVideoRenderer {
     @Override
     @RendererCapabilities.Capabilities
     public final int supportsFormat(Format format) {
-        String mimeType = Assertions.checkNotNull(format.sampleMimeType);
+        String mimeType = format.sampleMimeType;
         if (!FfmpegLibrary.isAvailable() || !MimeTypes.isVideo(mimeType)) {
             return C.FORMAT_UNSUPPORTED_TYPE;
-        } else if (!FfmpegLibrary.supportsFormat(format.sampleMimeType)) {
+        } else if (!FfmpegLibrary.supportsFormat(mimeType)) {
             return RendererCapabilities.create(C.FORMAT_UNSUPPORTED_SUBTYPE);
-        } else if (format.drmInitData != null) {
+        } else if (format.cryptoType != C.CRYPTO_TYPE_NONE) {
             return RendererCapabilities.create(C.FORMAT_UNSUPPORTED_DRM);
         } else {
             return RendererCapabilities.create(
                     C.FORMAT_HANDLED,
-                    ADAPTIVE_SEAMLESS,
+                    ADAPTIVE_NOT_SEAMLESS,
                     TUNNELING_NOT_SUPPORTED);
         }
     }
@@ -126,12 +125,15 @@ public final class FfmpegVideoRenderer extends DecoderVideoRenderer {
     @Override
     protected void renderOutputBufferToSurface(VideoDecoderOutputBuffer outputBuffer, Surface surface)
             throws FfmpegDecoderException {
-        if (decoder == null) {
-            throw new FfmpegDecoderException(
-                    "Failed to render output buffer to surface: decoder is not initialized.");
+        try {
+            if (decoder == null) {
+                throw new FfmpegDecoderException(
+                        "Failed to render output buffer to surface: decoder is not initialized.");
+            }
+            decoder.renderToSurface(outputBuffer, surface);
+        } finally {
+            outputBuffer.release();
         }
-        decoder.renderToSurface(outputBuffer, surface);
-        outputBuffer.release();
     }
 
     @Override


### PR DESCRIPTION
Surface rendering failures could skip output-buffer release, leaving the buffer checked out and its native frame retained until decoder teardown. Release the renderer-owned output in `finally`, including when the decoder is missing. Preserve the existing native pointer guard so output-first and decoder-first cleanup remain safe.

Correct the renderer's format capabilities:

- Reject a missing MIME type as unsupported instead of throwing.
- Reject non-NONE `cryptoType` values, including encrypted formats without DRM initialization data, consistently with the audio renderer.
- Report `ADAPTIVE_NOT_SEAMLESS` while retaining Media3's inherited no-reuse behavior.

Add six Android regressions using real JNI decoding and the existing VP9 fixture. They cover capabilities, inherited no-reuse, exactly-once output-owner release, repeated render failures with a one-buffer pool, a released Surface, successful rendering, and both cleanup orders.

Validation completed:

- NextLib: `:media3ext:testDebugUnitTest :media3ext:assembleDebug` passed with 11 JVM tests and all-ABI debug builds. `:media3ext:lintDebug :media3ext:assembleDebugAndroidTest` passed; lint has 0 errors and 2 existing dependency-update warnings.
- Device instrumentation: all 6 new tests passed without skips. Existing native tests passed all 8 groups, including invalid-buffer recovery on the same Surface.
- Disposable Next Player clone at `8d95d34f37222d100ff7b6d1668baa474db434db`: `./gradlew -PnextlibPath=<this-worktree> assembleDebug test :app:lintDebug ktlintCheck` passed; 205 tests, no failures/errors/skips. The clone aligned AGP to 9.4.0, set `ignoreFailures = false`, and added EventLogger for validation. App lint has 0 errors and 31 warnings in existing app/dependency code.
- The installed APK's native library matched the worktree's CMake output; DEX inspection confirmed the renderer changes. On an owned Android 16/API 36 ARM64 emulator, explicit FFmpeg playback passed normal playback, seven seeks, pause/resume, paused background/foreground with surface recreation, both directions of FFmpeg/platform switching, and H.264 HLS 320×180 → 640×360 across a discontinuity. No player errors or crashes appeared in the final logs.

Runtime coverage is limited to this 4-KiB-page emulator and its platform codecs; physical/vendor hardware and 16-KiB-page runtime behavior were not tested. Render failures were injected in regression tests. The owned emulator was stopped and removed after validation.
