### PR TITLE
Fix active decoder modes after codec reuse

### DIFF
--- a/media3ext/src/androidTest/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManagerLifecycleTest.kt
+++ b/media3ext/src/androidTest/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManagerLifecycleTest.kt
@@ -1,0 +1,66 @@
+package io.github.anilbeesetti.nextlib.media3ext.ffdecoder
+
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.Timeline
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DecoderCounters
+import androidx.media3.exoplayer.DecoderReuseEvaluation
+import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@UnstableApi
+class DecoderManagerLifecycleTest {
+    @Test
+    fun reusedDecodersRestoreActiveModesAfterRendererDisable() {
+        val manager = DecoderManager()
+        val listener = DecoderManager::class.java.getDeclaredField("analyticsListener").let {
+            it.isAccessible = true
+            it.get(manager) as AnalyticsListener
+        }
+        val event = AnalyticsListener.EventTime(0, Timeline.EMPTY, 0, null, 0, Timeline.EMPTY, 0, null, 0, 0)
+        val format = Format.Builder().setSampleMimeType(MimeTypes.VIDEO_H264).build()
+        manager.controller.decoderInfos["hardware"] = MediaCodecInfo.newInstance(
+            "hardware", MimeTypes.VIDEO_H264, MimeTypes.VIDEO_H264, null, true, false, false, false, false,
+        )
+        manager.controller.decoderInfos["software"] = MediaCodecInfo.newInstance(
+            "software", MimeTypes.AUDIO_AAC, MimeTypes.AUDIO_AAC, null, false, true, false, false, false,
+        )
+
+        for (reuse in listOf(
+            DecoderReuseEvaluation.REUSE_RESULT_YES_WITH_FLUSH,
+            DecoderReuseEvaluation.REUSE_RESULT_YES_WITH_RECONFIGURATION,
+            DecoderReuseEvaluation.REUSE_RESULT_YES_WITHOUT_RECONFIGURATION,
+        )) {
+            listener.onVideoDecoderInitialized(event, "hardware", 0, 0)
+            listener.onAudioDecoderInitialized(event, "software", 0, 0)
+            listener.onVideoDisabled(event, DecoderCounters())
+            listener.onAudioDisabled(event, DecoderCounters())
+            assertNull(manager.activeVideoMode)
+            assertNull(manager.activeAudioMode)
+
+            listener.onVideoInputFormatChanged(event, format, DecoderReuseEvaluation("hardware", format, format, reuse, 0))
+            assertEquals(DecoderMode.HARDWARE, manager.activeVideoMode)
+            assertNull(manager.activeAudioMode)
+            listener.onAudioInputFormatChanged(event, format, DecoderReuseEvaluation("software", format, format, reuse, 0))
+            assertEquals(DecoderMode.SOFTWARE, manager.activeAudioMode)
+        }
+
+        // The old codec's failed reuse evaluation can arrive after its replacement initializes.
+        listener.onVideoDecoderInitialized(event, "ffmpeg-h264", 0, 0)
+        listener.onAudioDecoderInitialized(event, "ffmpeg-aac", 0, 0)
+        val discarded = DecoderReuseEvaluation(
+            "hardware", format, format, DecoderReuseEvaluation.REUSE_RESULT_NO,
+            DecoderReuseEvaluation.DISCARD_REASON_WORKAROUND,
+        )
+        listener.onVideoInputFormatChanged(event, format, discarded)
+        listener.onAudioInputFormatChanged(event, format, discarded)
+        listener.onVideoInputFormatChanged(event, format, null)
+        listener.onAudioInputFormatChanged(event, format, null)
+        assertEquals(DecoderMode.FFMPEG, manager.activeVideoMode)
+        assertEquals(DecoderMode.FFMPEG, manager.activeAudioMode)
+    }
+}

--- a/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManager.kt
+++ b/media3ext/src/main/java/io/github/anilbeesetti/nextlib/media3ext/ffdecoder/DecoderManager.kt
@@ -2,9 +2,11 @@ package io.github.anilbeesetti.nextlib.media3ext.ffdecoder
 
 import android.os.Looper
 import androidx.media3.common.C
+import androidx.media3.common.Format
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DecoderCounters
+import androidx.media3.exoplayer.DecoderReuseEvaluation
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
@@ -58,6 +60,27 @@ class DecoderManager(
             initializationDurationMs: Long,
         ) {
             activeAudioMode = controller.activeMode(decoderName)
+        }
+
+        // Disabling a renderer can flush its codec. Reuse does not emit decoderInitialized again.
+        override fun onVideoInputFormatChanged(
+            eventTime: AnalyticsListener.EventTime,
+            format: Format,
+            decoderReuseEvaluation: DecoderReuseEvaluation?,
+        ) {
+            if (decoderReuseEvaluation != null && decoderReuseEvaluation.result != DecoderReuseEvaluation.REUSE_RESULT_NO) {
+                activeVideoMode = controller.activeMode(decoderReuseEvaluation.decoderName)
+            }
+        }
+
+        override fun onAudioInputFormatChanged(
+            eventTime: AnalyticsListener.EventTime,
+            format: Format,
+            decoderReuseEvaluation: DecoderReuseEvaluation?,
+        ) {
+            if (decoderReuseEvaluation != null && decoderReuseEvaluation.result != DecoderReuseEvaluation.REUSE_RESULT_NO) {
+                activeAudioMode = controller.activeMode(decoderReuseEvaluation.decoderName)
+            }
         }
 
         override fun onVideoDisabled(


### PR DESCRIPTION
Disabling a renderer can flush its codec, which Media3 later reuses without another decoder-initialized callback. `DecoderManager` cleared the active mode on disable and never restored it, leaving clients such as NextPlayer showing `-` during playback.

Restore active video/audio modes from successful decoder reuse evaluations. Ignore missing or failed reuse evaluations so they cannot overwrite a replacement decoder's state. Add a device regression covering both tracks, all successful reuse variants, and replacement initialization.

### Verification

Verified on September 12, 2026:

- `./gradlew :media3ext:testDebugUnitTest` — 11 tests passed.
- `./gradlew :media3ext:assembleDebugAndroidTest` and `DecoderManagerLifecycleTest` through `AndroidJUnitRunner` — failed before the fix (`expected HARDWARE, got null`), passed afterward.
- Integrated NextPlayer `assembleDebug test ktlintCheck` with local composite substitution — 206 app tests passed; test failures were enforced.
- Disposable Pixel 6a profile, Android 17 / API 37, ARM64, 16 KB pages: all six HW/SW+/SW transitions passed while paused and again while playing, with independent audio selection, subtitle loading, unsupported-mode recovery, and absent-track checks. No app crashes recorded.

The first SwiftShader run encountered a host emulator gRPC crash. The complete transition matrix passed after restarting with host graphics.

The companion [NextPlayer PR #1933](https://github.com/anilbeesetti/nextplayer/pull/1933) preserves the current playlist index when adding subtitles. Consumers need a nextlib release containing this fix, or local composite substitution.
